### PR TITLE
feat: Implements web page translation

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -69,5 +69,4 @@ linux:
         - AppImage
     icon: build/icons
     category: Utility
-    desktop:
-        StartupWMClass: fluent-reader
+    desktop: {}

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -44,6 +44,7 @@ type ArticleProps = {
 type ArticleState = {
     fontFamily: string
     fontSize: number
+    translate: boolean
     loadWebpage: boolean
     loadFull: boolean
     fullContent: string
@@ -60,6 +61,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
         this.state = {
             fontFamily: window.settings.getFont(),
             fontSize: window.settings.getFontSize(),
+            translate: false,
             loadWebpage: props.source.openTarget === SourceOpenTarget.Webpage,
             loadFull: props.source.openTarget === SourceOpenTarget.FullContent,
             fullContent: "",
@@ -288,8 +290,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                 loadWebpage:
                     this.props.source.openTarget === SourceOpenTarget.Webpage,
                 loadFull:
-                    this.props.source.openTarget ===
-                    SourceOpenTarget.FullContent,
+                    this.props.source.openTarget === SourceOpenTarget.FullContent,
             })
             if (this.props.source.openTarget === SourceOpenTarget.FullContent)
                 this.loadFull()
@@ -302,6 +303,17 @@ class Article extends React.Component<ArticleProps, ArticleState> {
             `#refocus div[data-iid="${this.props.item._id}"]`
         ) as HTMLElement
         if (refocus) refocus.focus()
+    }
+
+    toggleTranslation = () => {
+        if (this.state.translate) {
+            this.setState({ translate: false })
+        } else if (
+            this.props.item.link.startsWith("https://") ||
+            this.props.item.link.startsWith("http://")
+        ) {
+            this.setState({ translate: true })
+        }
     }
 
     toggleWebpage = () => {
@@ -439,6 +451,18 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                             this.props.toggleStarred(this.props.item)
                         }
                     />
+                    {this.state.loadWebpage && (
+                        <CommandBarButton
+                            title={
+                                this.state.translate
+                                    ? intl.get("article.showOriginal")
+                                    : intl.get("article.translate")
+                            }
+                            className={this.state.translate ? "active" : ""}
+                            iconProps={{ iconName: "Translate" }}
+                            onClick={this.toggleTranslation}
+                        />
+                    )}
                     <CommandBarButton
                         title={intl.get("article.loadFull")}
                         className={this.state.loadFull ? "active" : ""}
@@ -477,7 +501,9 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                     }
                     src={
                         this.state.loadWebpage
-                            ? this.props.item.link
+                            ? this.state.translate
+                                ? `https://translate.google.com/translate?sl=auto&tl=${this.props.locale.split("-")[0]}&u=${encodeURIComponent(this.props.item.link)}`
+                                : this.props.item.link
                             : this.articleView()
                     }
                     allowpopups={"true" as unknown as boolean}

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -44,7 +44,7 @@ type ArticleProps = {
 type ArticleState = {
     fontFamily: string
     fontSize: number
-    translate: boolean
+    translated: boolean
     loadWebpage: boolean
     loadFull: boolean
     fullContent: string
@@ -61,7 +61,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
         this.state = {
             fontFamily: window.settings.getFont(),
             fontSize: window.settings.getFontSize(),
-            translate: false,
+            translated: false,
             loadWebpage: props.source.openTarget === SourceOpenTarget.Webpage,
             loadFull: props.source.openTarget === SourceOpenTarget.FullContent,
             fullContent: "",
@@ -306,13 +306,13 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     }
 
     toggleTranslation = () => {
-        if (this.state.translate) {
-            this.setState({ translate: false })
+        if (this.state.translated) {
+            this.setState({ translated: false })
         } else if (
             this.props.item.link.startsWith("https://") ||
             this.props.item.link.startsWith("http://")
         ) {
-            this.setState({ translate: true })
+            this.setState({ translated: true })
         }
     }
 
@@ -454,11 +454,11 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                     {this.state.loadWebpage && (
                         <CommandBarButton
                             title={
-                                this.state.translate
-                                    ? intl.get("article.showOriginal")
-                                    : intl.get("article.translate")
+                                this.state.translated
+                                    ? intl.get("article.untranslate")
+                                    : intl.get("article.translated")
                             }
-                            className={this.state.translate ? "active" : ""}
+                            className={this.state.translated ? "active" : ""}
                             iconProps={{ iconName: "Translate" }}
                             onClick={this.toggleTranslation}
                         />
@@ -501,7 +501,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                     }
                     src={
                         this.state.loadWebpage
-                            ? this.state.translate
+                            ? this.state.translated
                                 ? `https://translate.google.com/translate?sl=auto&tl=${this.props.locale.split("-")[0]}&u=${encodeURIComponent(this.props.item.link)}`
                                 : this.props.item.link
                             : this.articleView()

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -65,7 +65,7 @@
         "unstar": "Remove star",
         "fontSize": "Font size",
         "translate": "Translate article",
-        "showOriginal": "Show original",
+        "untranslate": "Show original",
         "loadWebpage": "Load webpage",
         "loadFull": "Load full content",
         "notify": "Notify if fetched in background",

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -64,6 +64,8 @@
         "star": "Star",
         "unstar": "Remove star",
         "fontSize": "Font size",
+        "translate": "Translate article",
+        "showOriginal": "Show original",
         "loadWebpage": "Load webpage",
         "loadFull": "Load full content",
         "notify": "Notify if fetched in background",

--- a/src/scripts/i18n/pt-BR.json
+++ b/src/scripts/i18n/pt-BR.json
@@ -63,6 +63,8 @@
         "star": "Marcar como favorito",
         "unstar": "Remover marcação",
         "fontSize": "Tamanho da fonte",
+        "translate": "Traduzir artigo",
+        "showOriginal": "Mostrar original",
         "loadWebpage": "Carregar página web",
         "loadFull": "Carregar todo o conteúdo",
         "notify": "Notificar se atualizado em segundo plano",

--- a/src/scripts/i18n/pt-BR.json
+++ b/src/scripts/i18n/pt-BR.json
@@ -64,7 +64,7 @@
         "unstar": "Remover marcação",
         "fontSize": "Tamanho da fonte",
         "translate": "Traduzir artigo",
-        "showOriginal": "Mostrar original",
+        "untranslate": "Mostrar original",
         "loadWebpage": "Carregar página web",
         "loadFull": "Carregar todo o conteúdo",
         "notify": "Notificar se atualizado em segundo plano",

--- a/src/scripts/i18n/pt-PT.json
+++ b/src/scripts/i18n/pt-PT.json
@@ -64,6 +64,8 @@
         "star": "Marcar como favorito",
         "unstar": "Remover marcação",
         "fontSize": "Tamanho da fonte",
+        "translate": "Traduzir artigo",
+        "showOriginal": "Mostrar original",
         "loadWebpage": "Carregar página web",
         "loadFull": "Carregar todo o conteúdo",
         "notify": "Notificar se atualizado em segundo plano",

--- a/src/scripts/i18n/pt-PT.json
+++ b/src/scripts/i18n/pt-PT.json
@@ -65,7 +65,7 @@
         "unstar": "Remover marcação",
         "fontSize": "Tamanho da fonte",
         "translate": "Traduzir artigo",
-        "showOriginal": "Mostrar original",
+        "untranslate": "Mostrar original",
         "loadWebpage": "Carregar página web",
         "loadFull": "Carregar todo o conteúdo",
         "notify": "Notificar se atualizado em segundo plano",


### PR DESCRIPTION
This PR adds a feature to translate web pages in the integrated browser (using Google Translate).

However, it is currently present 100% of the time, meaning there is no switch for those who do not want this feature. I think it might be good to have a switch in settings so that the user can decide whether to enable it or not.

In any case, it is just a button that sends the page to Google Translate. Before the user taps the button, it should not connect to Google or do anything as far as I know.