### PR TITLE
Update Nix lock, add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/*.LICENSE.txt
 bin/*
 .DS_Store
 *.provisionprofile
+
+# Nix
+result

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,10 +1,13 @@
 let
-    nixpkgsTarball = fetchTarball {
-        url = "https://github.com/NixOS/nixpkgs/tarball/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054";
-        sha256 = "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=";
-    };
-    pkgs = import nixpkgsTarball { config = {}; overlays = []; };
+  nixpkgsTarball = fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/tarball/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054";
+    sha256 = "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=";
+  };
+  pkgs = import nixpkgsTarball {
+    config = { };
+    overlays = [ ];
+  };
 in
 {
-    fluentflame-reader = pkgs.callPackage ./package.nix {};
+  fluentflame-reader = pkgs.callPackage ./package.nix { };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,10 @@
+let
+    nixpkgsTarball = fetchTarball {
+        url = "https://github.com/NixOS/nixpkgs/tarball/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054";
+        sha256 = "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=";
+    };
+    pkgs = import nixpkgsTarball { config = {}; overlays = []; };
+in
+{
+    fluentflame-reader = pkgs.callPackage ./package.nix {};
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,7 @@
 let
   nixpkgsTarball = fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/tarball/85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054";
-    sha256 = "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=";
+    url = "https://github.com/NixOS/nixpkgs/tarball/7df7ff7d8e00218376575f0acdcc5d66741351ee";
+    sha256 = "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=";
   };
   pkgs = import nixpkgsTarball {
     config = { };

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -58,8 +58,8 @@ buildNpmPackage {
 
     mkdir -p $out/share/${pname}
     cp -Pr --no-preserve=ownership \
-      bin/*/*/*-unpacked/{locales,resources{,.pak}} \
-      $out/share/${pname}/
+        bin/*/*/*/{locales,resources{,.pak}} \
+        $out/share/${pname}/
 
     for icon in build/icons/*.png; do
       install -Dm644 $icon $out/share/icons/hicolor/$(basename ''${icon%.png})/apps/${pname}.png

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,12 +10,12 @@ let
   pname = "fluentflame-reader";
   myElectron = electron;
   desktopItem = makeDesktopItem {
-      name = pname;
-      exec = pname;
-      desktopName = "Fluentflame Reader";
-      categories = [ "Utility" ];
-      icon = pname;
-    };
+    name = pname;
+    exec = pname;
+    desktopName = "Fluentflame Reader";
+    categories = [ "Utility" ];
+    icon = pname;
+  };
 in
 
 buildNpmPackage {


### PR DESCRIPTION
This PR introduces:

- A default.nix, for nix users who don't use flakes.
- Updates to the pinned nix packages.

Adding the default.nix also meant fixing a bug in the resource copying, specifically with it
being restricted to `-unpacked` resources.

Also re-run the nix formatter.