### PR TITLE
fix: Update old Fluent Reader links to FluentFlame

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 <h3 align="center">Fluentflame Reader</h3>
 <p align="center">A modern desktop RSS reader given new life</p>
 <p align="center">
-  <img src="https://img.shields.io/github/v/release/yang991178/fluent-reader?label=version" />
-  <img src="https://img.shields.io/github/downloads/yang991178/fluent-reader/total" />
-  <img src="https://github.com/yang991178/fluent-reader/workflows/CI%2FCD%20Release/badge.svg" />
+  <img src="https://img.shields.io/github/v/release/FluentFlame/fluentflame-reader?label=version" />
+  <img src="https://img.shields.io/github/downloads/FluentFlame/fluentflame-reader/total" />
+  <img src="https://github.com/FluentFlame/fluentflame-reader/workflows/CI%2FCD%20Release/badge.svg" />
 </p>
 <hr />
 
@@ -31,7 +31,7 @@ If you are using Linux or an older version of Windows, you can [get Fluentflame 
 - Read the full content with the built-in article view or load webpages by default.
 - Search for articles with regular expressions or filter by read status.
 - Organize your subscriptions with folder-like groupings.
-- Single-key [keyboard shortcuts](https://github.com/yang991178/fluent-reader/wiki/Support#keyboard-shortcuts).
+- Single-key [keyboard shortcuts](https://github.com/FluentFlame/fluentflame-reader/wiki/Support#keyboard-shortcuts).
 - Hide, mark as read, or star articles automatically as they arrive with regular expression rules.
 - Fetch articles in the background and send push notifications.
 

--- a/src/components/settings/about.tsx
+++ b/src/components/settings/about.tsx
@@ -26,7 +26,7 @@ class AboutTab extends React.Component {
                         <Link
                             onClick={() =>
                                 window.utils.openExternal(
-                                    "https://github.com/yang991178/fluent-reader/wiki/Support#keyboard-shortcuts"
+                                    "https://github.com/FluentFlame/fluentflame-reader/wiki/Support#keyboard-shortcuts"
                                 )
                             }>
                             {intl.get("settings.shortcuts")}

--- a/src/components/settings/rules.tsx
+++ b/src/components/settings/rules.tsx
@@ -555,7 +555,7 @@ class RulesTab extends React.Component<RulesTabProps, RulesTabState> {
                         <Link
                             onClick={() =>
                                 window.utils.openExternal(
-                                    "https://github.com/yang991178/fluent-reader/wiki/Support#rules"
+                                    "https://github.com/FluentFlame/fluentflame-reader/wiki/Support#rules"
                                 )
                             }
                             style={{ marginLeft: 6 }}>

--- a/src/components/settings/service.tsx
+++ b/src/components/settings/service.tsx
@@ -51,7 +51,7 @@ export class ServiceTab extends React.Component<
     onServiceOptionChange = (_, option: IDropdownOption) => {
         if (option.key === -1) {
             window.utils.openExternal(
-                "https://github.com/yang991178/fluent-reader/issues/23"
+                "https://github.com/FluentFlame/fluentflame-reader/issues/23"
             )
         } else {
             this.setState({ type: option.key as number })
@@ -128,7 +128,7 @@ export class ServiceTab extends React.Component<
                         <Link
                             onClick={() =>
                                 window.utils.openExternal(
-                                    "https://github.com/yang991178/fluent-reader/wiki/Support#services"
+                                    "https://github.com/FluentFlame/fluentflame-reader/wiki/Support#services"
                                 )
                             }
                             style={{ marginLeft: 6 }}>

--- a/src/components/settings/services/inoreader.tsx
+++ b/src/components/settings/services/inoreader.tsx
@@ -38,7 +38,7 @@ const endpointOptions: IDropdownOption[] = [
 
 const openSupport = () =>
     window.utils.openExternal(
-        "https://github.com/yang991178/fluent-reader/wiki/Support#inoreader"
+        "https://github.com/FluentFlame/fluentflame-reader/wiki/Support#inoreader"
     )
 
 class InoreaderConfigsTab extends React.Component<


### PR DESCRIPTION
## Description

This PR updates all references from the old repository (yang991178/fluent-reader) to the new FluentFlame repository, as requested in #44.

## Changes

### Files Updated:
- **README.md**: Updated badges and documentation links
- **Settings Components**: Updated help and wiki links  
- **Service Configuration**: Updated support documentation URLs

### Specific Updates:
- Version badge URL
- Downloads badge URL
- CI/CD workflow badge URL
- Keyboard shortcuts wiki link
- Rules documentation link
- Services support documentation
- Inoreader support link

## Impact

✅ **User-facing**: Users will now be directed to the correct repository
✅ **Documentation**: Help links point to accurate resources
✅ **Consistency**: All references use the new repository name

## Testing

- [x] Verified all changed links point to valid URLs
- [x] No broken functionality (links only)
- [x] Consistent formatting maintained

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Maintenance/refactoring

## Related Issues

Fixes #44

---

**Note**: This PR addresses the link updates portion of issue #44. Screenshots and landing page updates can be handled in separate PRs.