### PR TITLE
Improved thumbnail parsing

### DIFF
--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -76,8 +76,9 @@ export class RSSItem {
         } else if (parsed.image && typeof parsed.image === "string") {
             item.thumb = parsed.image
         } 
-        else if (parsed.mediaThumbnail?.$?.url) {
-            item.thumb = parsed.mediaThumbnail.$.url;
+        else if (parsed.mediaThumbnails) {
+            const images = parsed.mediaThumbnails.filter(t => t.$?.url);
+            if(images.length > 0) item.thumb = images[0].$.url;
         }
         else if (parsed.mediaContent) {
             let images = parsed.mediaContent.filter(

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -26,7 +26,7 @@ const rssParser = new Parser({
         item: [
             "thumb",
             "image",
-            ["media:thumbnail", "mediaThumbnail"],
+            ["media:thumbnail", "mediaThumbnails", { keepArray: true }],
             ["content:encoded", "fullContent"],
             ["media:content", "mediaContent", { keepArray: true }],
         ],


### PR DESCRIPTION
Hi!
I've noticed that articles from some feeds don't have their thumbnails, even though they are spec-compliant so I did a quick fix for that.
There are some caveats, though they are in keeping with the existing codebase.
https://www.rssboard.org/media-rss#media-thumbnails - I'm only using the first thumbnail, similar to how `media:content` is handled currently. I'm also not using any properties except for `url`.
https://www.rssboard.org/media-rss#media-content - Since the `medium` field is optional, I've added `type` check as well, but I'm only checking for `image/` types, so any video thumbnails won't be grabbed, though they aren't currently supported anyway.