### PR TITLE
Remove scrollbar styling

### DIFF
--- a/resources/styles/scroll.css
+++ b/resources/styles/scroll.css
@@ -1,25 +1,10 @@
-::-webkit-scrollbar {
-    width: 16px;
+body {
+    scrollbar-color: #0004 transparent;
+    scrollbar-gutter: stable;
 }
-::-webkit-scrollbar-thumb {
-    border: 2px solid transparent;
-    background-color: #0004;
-    background-clip: padding-box;
-}
-::-webkit-scrollbar-thumb:hover {
-    background-color: #0006;
-}
-::-webkit-scrollbar-thumb:active {
-    background-color: #0008;
-}
+
 @media (prefers-color-scheme: dark) {
-    ::-webkit-scrollbar-thumb {
-        background-color: #fff4;
-    }
-    ::-webkit-scrollbar-thumb:hover {
-        background-color: #fff6;
-    }
-    ::-webkit-scrollbar-thumb:active {
-        background-color: #fff8;
+    body {
+        scrollbar-color: #fff4 transparent;
     }
 }


### PR DESCRIPTION
This scrollbar styling caused significant full page paint delays, leading to scroll response jankiness. This isn't the only thing causing Issue #32, but it's one that forces a repaint on every scroll frame change, leading to hundreds of unnecessary document repaints.