### PR TITLE
Remove scrollbar gutter

### DIFF
--- a/resources/styles/scroll.css
+++ b/resources/styles/scroll.css
@@ -1,6 +1,5 @@
 body {
     scrollbar-color: #0004 transparent;
-    scrollbar-gutter: stable;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
This causes extra padding at the body level that we don't need, with no obvious benefit. Force the gutter on individual components, not the body.