### PR TITLE
Fix article scrollbar colour

### DIFF
--- a/resources/styles/scroll.css
+++ b/resources/styles/scroll.css
@@ -1,9 +1,9 @@
-body {
+html {
     scrollbar-color: #0004 transparent;
 }
 
 @media (prefers-color-scheme: dark) {
-    body {
+    html {
         scrollbar-color: #fff4 transparent;
     }
 }


### PR DESCRIPTION
The scrollbar inside articles is on the "html" tag itself, not its body because of its embedded webview frame.

Change the CSS to fix this.