### PR TITLE
Add the data: protocol to allowed img-srcs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src-elem 'self'; img-src *; style-src 'self' 'unsafe-inline'; font-src 'self' https://static2.sharepointonline.com https://res-1.cdn.office.net; connect-src https: http:">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src-elem 'self'; img-src * data:; style-src 'self' 'unsafe-inline'; font-src 'self' https://static2.sharepointonline.com https://res-1.cdn.office.net; connect-src https: http:">
     <title>Fluentflame Reader</title>
     <link rel="stylesheet" href="index.css">
   </head>


### PR DESCRIPTION
This allows us to load thumbnails and favicons
that use the data: protocol instead of just http/https.