### PR TITLE
Context Menu Fixes

### DIFF
--- a/src/components/context-menu.tsx
+++ b/src/components/context-menu.tsx
@@ -13,13 +13,18 @@ import {
     ContextualMenuItemType,
     DirectionalHint,
 } from "@fluentui/react";
-import { closeContextMenu, ContextMenuType } from "../scripts/models/app";
 import {
+    ContextMenuType,
+    closeContextMenu,
+    setSettingsTab,
+    toggleSettings,
+} from "../scripts/models/app";
+import {
+    RSSItem,
     fetchItems,
     markAllRead,
     markRead,
     markUnread,
-    RSSItem,
     toggleHidden,
     toggleStarred,
 } from "../scripts/models/item";
@@ -531,7 +536,8 @@ function GroupContextMenu() {
             text: intl.get("context.manageSources"),
             iconProps: { iconName: "Settings" },
             onClick: () => {
-                dispatch(markAllRead(sids));
+                dispatch(setSettingsTab("sources"));
+                dispatch(toggleSettings(true, sids));
             },
         },
     ];

--- a/src/components/settings.tsx
+++ b/src/components/settings.tsx
@@ -19,15 +19,17 @@ import { initTouchBarWithTexts } from "../scripts/utils";
 
 type SettingsProps = {
     display: boolean;
+    currentTab: string | null;
     blocked: boolean;
     exitting: boolean;
     close: () => void;
+    setTab: (newTab: string | null) => void;
 };
 
 const INITIAL_PANEL: string = "app";
 
 export default function Settings(props: SettingsProps): React.JSX.Element {
-    const [currentPanel, setCurrentPanel] = React.useState(INITIAL_PANEL);
+    const getCurrentTab = () => props.currentTab ?? INITIAL_PANEL;
 
     const onKeyDown = (event: KeyboardEvent) => {
         if (event.key === "Escape" && !props.exitting) {
@@ -50,7 +52,7 @@ export default function Settings(props: SettingsProps): React.JSX.Element {
         _ev: React.MouseEvent<HTMLElement>,
         item: INavLink,
     ) => {
-        setCurrentPanel(item.key);
+        props.setTab(item.key);
     };
 
     return (
@@ -79,13 +81,13 @@ export default function Settings(props: SettingsProps): React.JSX.Element {
                     )}
                     <div className="settings-inner-container">
                         <Nav
-                            initialSelectedKey={currentPanel}
+                            initialSelectedKey={getCurrentTab()}
                             className="settings-nav"
                             groups={makeNavLinkGroups()}
                             onLinkClick={onLinkClick}
                         />
                         <div className="settings-panel">
-                            {renderSettingsPanel(currentPanel)}
+                            {renderSettingsPanel(getCurrentTab())}
                         </div>
                     </div>
                 </div>

--- a/src/containers/settings-container.tsx
+++ b/src/containers/settings-container.tsx
@@ -1,13 +1,14 @@
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
 import { RootState } from "../scripts/reducer";
-import { exitSettings } from "../scripts/models/app";
+import { exitSettings, setSettingsTab } from "../scripts/models/app";
 import Settings from "../components/settings";
 
 const getApp = (state: RootState) => state.app;
 
 const mapStateToProps = createSelector([getApp], (app) => ({
     display: app.settings.display,
+    currentTab: app.settings.tab,
     blocked:
         !app.sourceInit ||
         app.syncing ||
@@ -19,6 +20,7 @@ const mapStateToProps = createSelector([getApp], (app) => ({
 const mapDispatchToProps = (dispatch) => {
     return {
         close: () => dispatch(exitSettings()),
+        setTab: (newTab: string | null) => dispatch(setSettingsTab(newTab)),
     };
 };
 

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -91,6 +91,7 @@ export class AppState {
         changed: false,
         sids: new Array<number>(),
         saving: false,
+        tab: null,
     };
     logMenu = {
         display: false,
@@ -188,6 +189,7 @@ export interface MenuActionTypes {
 }
 
 export const TOGGLE_SETTINGS = "TOGGLE_SETTINGS";
+export const SET_SETTINGS_TAB = "SET_SETTINGS_TAB";
 export const SAVE_SETTINGS = "SAVE_SETTINGS";
 export const FREE_MEMORY = "FREE_MEMORY";
 
@@ -195,6 +197,11 @@ interface ToggleSettingsAction {
     type: typeof TOGGLE_SETTINGS;
     open: boolean;
     sids: number[];
+    tab: string | null;
+}
+interface SetSettingsTabAction {
+    type: typeof SET_SETTINGS_TAB;
+    tab: string | null;
 }
 interface SaveSettingsAction {
     type: typeof SAVE_SETTINGS;
@@ -205,6 +212,7 @@ interface FreeMemoryAction {
 }
 export type SettingsActionTypes =
     | ToggleSettingsAction
+    | SetSettingsTabAction
     | SaveSettingsAction
     | FreeMemoryAction;
 
@@ -283,6 +291,11 @@ export const toggleSettings = (open = true, sids = new Array<number>()) => ({
     type: TOGGLE_SETTINGS,
     open: open,
     sids: sids,
+});
+
+export const setSettingsTab = (newTab: string | null) => ({
+    type: SET_SETTINGS_TAB,
+    tab: newTab,
 });
 
 export function exitSettings(): AppThunk<Promise<void>> {
@@ -676,10 +689,19 @@ export function appReducer(
             return {
                 ...state,
                 settings: {
+                    ...state.settings,
                     display: action.open,
                     changed: false,
                     sids: action.sids,
                     saving: false,
+                },
+            };
+        case SET_SETTINGS_TAB:
+            return {
+                ...state,
+                settings: {
+                    ...state.settings,
+                    tab: action.tab,
                 },
             };
         case TOGGLE_LOGS:


### PR DESCRIPTION
In the sidebar menu's context menu actions, "sync" and "manage sources" do the entirely wrong thing! They actually mark all items of that source as read, regardless of what you click!

This is a bug in the original Fluent Reader, and we're finally fixing it in Fluentflame.