### PR TITLE
Add permission for uploading artefacts part 2

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -9,7 +9,7 @@ jobs:
     release_linux_x86_64_appimage:
         runs-on: "ubuntu-latest"
         permissions:
-            deployment: "write"
+            deployments: "write"
         steps:
             - uses: "actions/checkout@v5"
             - name: "Set Up Node"


### PR DESCRIPTION
It's got an `s` at the end? Maybe?

Actual ref to the permissions block:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions