### PR TITLE
Replace release-macos.yml shell with bash

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -23,7 +23,7 @@ jobs:
             - run: "npm run package-universal-mac"
             - name: "Get App Version"
               id: "package-version"
-              shell: zsh
+              shell: bash
               run: |
                 version="$(jq -r '.version' package.json)"
                 echo "version=${version}"


### PR DESCRIPTION
zsh is apparently not a valid shell, which is very confusing to me as it's Mac's default shell.