### PR TITLE
Change path for resource article .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-dist/article/article.js text eol=lf
-dist/article/mercury.web.js text eol=lf
+# Very important for Electron SRI hash consistency!
+resources/article/article.js text eol=lf
+resources/article/mercury.web.js text eol=lf


### PR DESCRIPTION
These were previously in the dist directory, but
they were moved later. Make sure that these files
always preserve their line endings regardless of
the operating system.

Fixes #97