### PR TITLE
get-version should return npm version

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -7,6 +7,7 @@ import {
     clipboard,
     systemPreferences,
 } from "electron";
+import { version } from "../../package.json"
 import { WindowManager } from "./window";
 import fs = require("fs");
 import { ImageCallbackTypes, TouchBarTexts } from "../schema-types";
@@ -49,7 +50,7 @@ export function setUtilsListeners(manager: WindowManager) {
     });
 
     ipcMain.on("get-version", (event) => {
-        event.returnValue = app.getVersion();
+        event.returnValue = version;
     });
 
     ipcMain.handle("open-external", (_, url: string, background: boolean) => {


### PR DESCRIPTION
app.getVersion() can instead return the electron app version, not the version of the package.

This does leak our package info into the app, but this is all BSD-3 and freely available. So it's not really a risk of anything.

Fixes #104 