### PR TITLE
Get title from snippet where possible

### DIFF
--- a/resources/styles/cards.css
+++ b/resources/styles/cards.css
@@ -178,7 +178,7 @@
     margin: 10px 12px;
     position: relative;
     -webkit-line-clamp: 3;
-    overflow: hidden;
+    overflow-wrap: break-word;
     display: -webkit-box;
     -webkit-box-orient: vertical;
 }

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -364,10 +364,11 @@ class Article extends React.Component<ArticleProps, ArticleState> {
                 ? this.state.fullContent
                 : this.props.item.content,
         );
+        const title = RSSItem.getTitle(this.props.item);
         const h = encodeURIComponent(
             renderToString(
                 <>
-                    <p className="title">{this.props.item.title}</p>
+                    <p className="title">{title}</p>
                     <p className="date">
                         {this.props.item.date.toLocaleString(
                             this.props.locale,

--- a/src/components/cards/compact-card.tsx
+++ b/src/components/cards/compact-card.tsx
@@ -3,6 +3,7 @@ import { Card } from "./card";
 import CardInfo from "./info";
 import Time from "../utils/time";
 import Highlights from "./highlights";
+import { RSSItem } from "../../scripts/models/item";
 import { SourceTextDirection } from "../../scripts/models/source";
 
 const className = (props: Card.Props) => {
@@ -13,6 +14,7 @@ const className = (props: Card.Props) => {
 };
 
 function CompactCard(props: Card.Props): React.JSX.Element {
+    const title = RSSItem.getTitle(props.item);
     return (
         <div
             className={className(props)}
@@ -22,11 +24,7 @@ function CompactCard(props: Card.Props): React.JSX.Element {
             <CardInfo source={props.source} item={props.item} hideTime />
             <div className="data">
                 <span className="title">
-                    <Highlights
-                        text={props.item.title}
-                        filter={props.filter}
-                        title
-                    />
+                    <Highlights text={title} filter={props.filter} title />
                 </span>
                 <span className="snippet">
                     <Highlights

--- a/src/components/cards/default-card.tsx
+++ b/src/components/cards/default-card.tsx
@@ -3,6 +3,7 @@ import { Card } from "./card";
 import CardInfo from "./info";
 import Highlights from "./highlights";
 import { SourceTextDirection } from "../../scripts/models/source";
+import { RSSItem } from "../../scripts/models/item";
 import CardThumbnail from "./thumbnail";
 
 const className = (props: Card.Props) => {
@@ -17,28 +18,31 @@ const HEADER_IMG_WIDTH = 256;
 const HEADER_IMG_HEIGHT = 144;
 const RESCALE_FACTOR = 2; // Should be at least 1.
 
-const DefaultCard: React.FunctionComponent<Card.Props> = (props) => (
-    <div
-        className={className(props)}
-        {...Card.bindEventsToProps(props)}
-        data-iid={props.item.iid}
-        data-is-focusable>
-        <CardThumbnail className="bg" item={props.item} />
-        <div className="bg"></div>
-        <CardThumbnail
-            className="head"
-            item={props.item}
-            width={HEADER_IMG_WIDTH * RESCALE_FACTOR}
-            height={HEADER_IMG_HEIGHT * RESCALE_FACTOR}
-        />
-        <CardInfo source={props.source} item={props.item} />
-        <h3 className="title">
-            <Highlights text={props.item.title} filter={props.filter} title />
-        </h3>
-        <p className={"snippet" + (props.item.thumb ? "" : " show")}>
-            <Highlights text={props.item.snippet} filter={props.filter} />
-        </p>
-    </div>
-);
+function DefaultCard(props: Card.Props): React.JSX.Element {
+    const title = RSSItem.getTitle(props.item);
+    return (
+        <div
+            className={className(props)}
+            {...Card.bindEventsToProps(props)}
+            data-iid={props.item.iid}
+            data-is-focusable>
+            <CardThumbnail className="bg" item={props.item} />
+            <div className="bg"></div>
+            <CardThumbnail
+                className="head"
+                item={props.item}
+                width={HEADER_IMG_WIDTH * RESCALE_FACTOR}
+                height={HEADER_IMG_HEIGHT * RESCALE_FACTOR}
+            />
+            <CardInfo source={props.source} item={props.item} />
+            <h3 className="title">
+                <Highlights text={title} filter={props.filter} title />
+            </h3>
+            <p className={"snippet" + (props.item.thumb ? "" : " show")}>
+                <Highlights text={props.item.snippet} filter={props.filter} />
+            </p>
+        </div>
+    );
+}
 
 export default DefaultCard;

--- a/src/components/cards/list-card.tsx
+++ b/src/components/cards/list-card.tsx
@@ -4,6 +4,7 @@ import CardInfo from "./info";
 import Highlights from "./highlights";
 import { ViewConfigs } from "../../schema-types";
 import { SourceTextDirection } from "../../scripts/models/source";
+import { RSSItem } from "../../scripts/models/item";
 import CardThumbnail from "./thumbnail";
 
 const className = (props: Card.Props) => {
@@ -18,6 +19,7 @@ const className = (props: Card.Props) => {
 
 function ListCard(props: Card.Props): React.JSX.Element {
     const hasThumbs = props.item.thumbnails?.length != 0;
+    const title = RSSItem.getTitle(props.item);
     return (
         <div
             className={className(props)}
@@ -32,11 +34,7 @@ function ListCard(props: Card.Props): React.JSX.Element {
             <div className="data">
                 <CardInfo source={props.source} item={props.item} />
                 <h3 className="title">
-                    <Highlights
-                        text={props.item.title}
-                        filter={props.filter}
-                        title
-                    />
+                    <Highlights text={title} filter={props.filter} title />
                 </h3>
                 {Boolean(props.viewConfigs & ViewConfigs.ShowSnippet) && (
                     <p className="snippet">

--- a/src/components/cards/magazine-card.tsx
+++ b/src/components/cards/magazine-card.tsx
@@ -3,6 +3,7 @@ import { Card } from "./card";
 import CardInfo from "./info";
 import Highlights from "./highlights";
 import { SourceTextDirection } from "../../scripts/models/source";
+import { RSSItem } from "../../scripts/models/item";
 import CardThumbnail from "./thumbnail";
 
 const className = (props: Card.Props) => {
@@ -15,6 +16,7 @@ const className = (props: Card.Props) => {
 
 function MagazineCard(props: Card.Props): React.JSX.Element {
     const hasThumbs = props.item.thumbnails?.length != 0;
+    const title = RSSItem.getTitle(props.item);
     return (
         <div
             className={className(props)}
@@ -29,11 +31,7 @@ function MagazineCard(props: Card.Props): React.JSX.Element {
             <div className="data">
                 <div>
                     <h3 className="title">
-                        <Highlights
-                            text={props.item.title}
-                            filter={props.filter}
-                            title
-                        />
+                        <Highlights text={title} filter={props.filter} title />
                     </h3>
                     <p className="snippet">
                         <Highlights

--- a/src/components/cards/thumbnail.tsx
+++ b/src/components/cards/thumbnail.tsx
@@ -21,8 +21,7 @@ const mediaElement = (
             src={src}
             className={className}
             width={width}
-            height={height}
-        ></CachedImg>
+            height={height}></CachedImg>
     );
 };
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -7,7 +7,7 @@ import {
     clipboard,
     systemPreferences,
 } from "electron";
-import { version } from "../../package.json"
+import { version } from "../../package.json";
 import { WindowManager } from "./window";
 import fs = require("fs");
 import { ImageCallbackTypes, TouchBarTexts } from "../schema-types";

--- a/src/scripts/db.ts
+++ b/src/scripts/db.ts
@@ -20,11 +20,11 @@ export interface SourceEntry {
 export interface ItemEntry {
     iid: number;
     source: number;
-    title: string;
+    title: string | null;
     link: string;
     date: Date;
     fetchedDate: Date;
-    thumb?: string;
+    thumb?: never;
     thumbnails?: ThumbnailAttributes[];
     content: string;
     snippet: string;
@@ -44,6 +44,8 @@ fluentDB.version(4).stores({
     sources: `++sid, &url`,
     items: `++iid, source, date, serviceRef`,
 });
+
+// Introduce thumbnail types.
 fluentDB
     .version(5)
     .stores({
@@ -51,6 +53,12 @@ fluentDB
         items: `++iid, source, date, serviceRef`,
     })
     .upgrade(migrateThumbs);
+
+// Introduce optional titles, delete thumbs.
+fluentDB.version(6).stores({
+    sources: `++sid, &url`,
+    items: `++iid, source, date, serviceRef`,
+});
 
 export async function calculateItemSize(): Promise<number> {
     await fluentDB.open();

--- a/src/scripts/models/feed.ts
+++ b/src/scripts/models/feed.ts
@@ -67,11 +67,11 @@ export class FeedFilter {
                 const regex = RegExp(filter.search, flags);
                 if (type & FilterType.FullSearch) {
                     return (
-                        item.title.match(regex) != null ||
+                        (item.title ?? "").match(regex) != null ||
                         item.snippet.match(regex) != null
                     );
                 } else {
-                    return item.title.match(regex) != null;
+                    return (item.title ?? "").match(regex) != null;
                 }
             }
             return true;
@@ -90,11 +90,11 @@ export class FeedFilter {
             if (type & FilterType.FullSearch) {
                 flag =
                     flag &&
-                    (regex.test(item.title) || regex.test(item.snippet));
+                    (regex.test(item.title ?? "") || regex.test(item.snippet));
             } else if (type & FilterType.CreatorSearch) {
                 flag = flag && regex.test(item.creator || "");
             } else {
-                flag = flag && regex.test(item.title);
+                flag = flag && regex.test(item.title ?? "");
             }
         }
         return Boolean(flag);

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -32,7 +32,7 @@ import { ThumbnailTypePref } from "../../schema-types";
 export class RSSItem {
     iid: number;
     source: number;
-    title: string;
+    title: string | null;
     link: string;
     date: Date;
     fetchedDate: Date;
@@ -53,7 +53,7 @@ export class RSSItem {
             if (content && typeof content !== "string") delete item[field];
         }
         this.source = source.sid;
-        this.title = item.title || intl.get("article.untitled");
+        this.title = item.title || null;
         this.link = item.link || "";
         this.fetchedDate = new Date();
         this.date = new Date(item.isoDate ?? item.pubDate ?? this.fetchedDate);
@@ -62,6 +62,24 @@ export class RSSItem {
         this.starred = false;
         this.hidden = false;
         this.notify = false;
+    }
+
+    /**
+     * Return title or renderable alternative that can act as a title if
+     * none exists.
+     */
+    static getTitle(item: RSSItem): string {
+        if (item.title) {
+            return item.title.trim();
+        }
+        const maxLength = 45;
+        if (item.snippet) {
+            if (item.snippet.length > maxLength - 1) {
+                return item.snippet.slice(0, maxLength - 1).trim() + "…";
+            }
+            return item.snippet.trim();
+        }
+        return intl.get("article.untitled");
     }
 
     static async fetchHead(url: string): Promise<string> {


### PR DESCRIPTION
It's not uncommon for posts to have no title. At present time, Fluentflame reader does something incredibly stupid: write into the database what the title should be based on your current localisation. This incredibly stupid.

Let's not do that. We first guess what a valid title should be from a snippet, and we use that. If no snippet is available, then we go to the untitled text.

Also update the CSS so we can wrap text correctly.