### PR TITLE
Add better magazine card widths

### DIFF
--- a/resources/styles/cards.css
+++ b/resources/styles/cards.css
@@ -276,7 +276,9 @@
 }
 
 .magazine-card {
-    max-width: 700px;
+    /* This complicated calculation is to allow it to scale with small
+     * window sizes. */
+    width: min(700px, calc(100vw - 90px));
     padding: 24px;
     max-height: 160px;
     display: flex;


### PR DESCRIPTION
The original design of this used a fixed width, which looked much better. When we changed the style to fit smaller screens, this was lost. This change allows us the best of both worlds, keeping us at 700px until the screen is too small.