### PR TITLE
Fix thumbnail opengraph parsing

### DIFF
--- a/src/components/cards/default-card.tsx
+++ b/src/components/cards/default-card.tsx
@@ -20,6 +20,8 @@ const RESCALE_FACTOR = 2; // Should be at least 1.
 
 function DefaultCard(props: Card.Props): React.JSX.Element {
     const title = RSSItem.getTitle(props.item);
+    const hasThumbnail =
+        props.item.thumbnails.length > 0 || props.item.thumb != null;
     return (
         <div
             className={className(props)}
@@ -38,7 +40,7 @@ function DefaultCard(props: Card.Props): React.JSX.Element {
             <h3 className="title">
                 <Highlights text={title} filter={props.filter} title />
             </h3>
-            <p className={"snippet" + (props.item.thumb ? "" : " show")}>
+            <p className={"snippet" + (hasThumbnail ? "" : " show")}>
                 <Highlights text={props.item.snippet} filter={props.filter} />
             </p>
         </div>

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -245,7 +245,7 @@
         "fetchInterval": "Automatic fetch interval",
         "never": "Never",
         "thumbnails": {
-            "prefLabel": "Preffered thumbnail source",
+            "prefLabel": "Preferred thumbnail source",
             "opengraph": "OpenGraph",
             "mediaThumbnail": "RSS media:thumbnail",
             "thumb": "RSS thumb",

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -121,7 +121,7 @@ export class RSSItem {
             } catch (e) {
                 // We don't need an OpenGraph thumbnail. Skip it if it fails.
                 console.warn(
-                    `Failed to fetch open graph thumb from ${parsed.link}`,
+                    `Failed to fetch OpenGraph thumb from ${parsed.link}`,
                     e,
                 );
             }

--- a/src/scripts/thumb-utils.ts
+++ b/src/scripts/thumb-utils.ts
@@ -61,7 +61,7 @@ async function makeOpenGraphThumbnail(
     return result;
 }
 
-const OPENGRAPH_REGEX = /og:(?:image|video)/gi;
+const OPENGRAPH_REGEX = /og:(?:image|video)/i;
 
 export async function fetchOpenGraphThumb(
     url: URL,


### PR DESCRIPTION
Previously, we were incorrectly setting the
sticky global bit which was breaking test.

Also fix a typo in the en-US strings, and
fix snippet display detection.

See:
https://bsky.app/profile/rebane2001.bsky.social/post/3lz6guppi2s22