### PR TITLE
Change insertSource insert ids

### DIFF
--- a/src/scripts/models/service.ts
+++ b/src/scripts/models/service.ts
@@ -129,7 +129,7 @@ function updateSources(
                 if (docs.length === 0) {
                     // Create a new source
                     forceSettings();
-                    const inserted = await dispatch(insertSource(s));
+                    const inserted = await insertSource(s);
                     inserted.unreadCount = 0;
                     dispatch(addSourceSuccess(inserted, true));
                     window.settings.saveGroups(getState().groups);

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -278,22 +278,24 @@ export function addSourceFailure(err, batch: boolean): SourceActionTypes {
 }
 
 let insertPromises = Promise.resolve();
-export function insertSource(source: RSSSource): AppThunk<Promise<RSSSource>> {
-    return (_, getState) => {
-        return new Promise((resolve, reject) => {
-            insertPromises = insertPromises.then(async () => {
-                let sids = Object.values(getState().sources).map((s) => s.sid);
-                source.sid = Math.max(...sids, -1) + 1;
-                try {
-                    await db.fluentDB.sources.add(source);
-                    resolve(source);
-                } catch (err) {
-                    if (err.code === 201) reject(intl.get("sources.exist"));
-                    else reject(err);
-                }
-            });
+export function insertSource(source: RSSSource): Promise<RSSSource> {
+    return new Promise((resolve, reject) => {
+        insertPromises = insertPromises.then(async () => {
+            const existingSources = await db.fluentDB.sources
+                .where("url")
+                .equals(source.url)
+                .toArray();
+            if (existingSources.length > 0) {
+                reject(intl.get("sources.exist"));
+            }
+            try {
+                await db.fluentDB.sources.add(source);
+                resolve(source);
+            } catch (err) {
+                reject(err);
+            }
         });
-    };
+    });
 }
 
 export function addSource(
@@ -308,7 +310,7 @@ export function addSource(
             const source = new RSSSource(url, name);
             try {
                 const feed = await RSSSource.fetchMetaData(source);
-                const inserted = await dispatch(insertSource(source));
+                const inserted = await insertSource(source);
                 inserted.unreadCount = feed.items.length;
                 dispatch(addSourceSuccess(inserted, batch));
                 window.settings.saveGroups(getState().groups);


### PR DESCRIPTION
We shouldn't need to set the insert source ID directly, as DexieDB should handle auto-increment for us.

Tested by adding and removing source.

Mildly Relevant for #120, though doesn't fix it. 