### PR TITLE
Fix icons on Linux Wayland

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -13,8 +13,10 @@ let
     name = pname;
     exec = pname;
     desktopName = "Fluentflame Reader";
-    categories = [ "Utility" ];
+    categories = [ "Network" "Feed" ];
+    comment = "A modern desktop RSS reader given new life";
     icon = pname;
+    startupWMClass = pname;
   };
 in
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "fluentflame-reader",
+  "productName": "Fluentflame Reader",
+  "desktopName": "fluentflame-reader.desktop",
   "version": "2.1.0",
   "description": "A modern desktop RSS reader given new life",
   "main": "./dist/electron.js",

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -31,6 +31,8 @@ if (!process.mas) {
     }
 }
 
+// Critical for WM Class identification
+app.setName("fluentflame-reader");
 if (!app.isPackaged) app.setAppUserModelId(process.execPath);
 else if (process.platform === "win32")
     app.setAppUserModelId("org.fluentflame.fluentflamereader");


### PR DESCRIPTION
Newer wayland seems to have issues with the icon not correctly rendering. This can be fixed with app.setName before launch, as well as setting desktopName directly in the package.json.

While we're here, update the desktop entry for NixOS. These were out of date.