### PR TITLE
Move setName into packaged check

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -31,9 +31,11 @@ if (!process.mas) {
     }
 }
 
-// Critical for WM Class identification
-app.setName("fluentflame-reader");
-if (!app.isPackaged) app.setAppUserModelId(process.execPath);
+if (!app.isPackaged) {
+    // Critical for WM Class identification
+    app.setName("fluentflame-reader");
+    app.setAppUserModelId(process.execPath);
+}
 else if (process.platform === "win32")
     app.setAppUserModelId("org.fluentflame.fluentflamereader");
 


### PR DESCRIPTION
This prevents the developer build from polluting the actual reader's production database.