### PR TITLE
Force userData path to $appData/fluentflame-reader

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,9 +22,9 @@ in
 
 buildNpmPackage {
   inherit pname;
-  version = "2.1.0";
+  version = "2.1.1";
   src = ../.;
-  npmDepsHash = "sha256-LRn+eZDFLuWHZa3AB56Gk5kwfMoNuirmE9ygQ1T3G0k=";
+  npmDepsHash = "sha256-wxT5GBYFU7U8uh7xzCxNb9OT9Jj8yzY+8Hsn+dJWSdU=";
   makeCacheWritable = true;
 
   env = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluentflame-reader",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluentflame-reader",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "dompurify": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "fluentflame-reader",
-  "productName": "Fluentflame Reader",
   "desktopName": "fluentflame-reader.desktop",
   "version": "2.1.0",
   "description": "A modern desktop RSS reader given new life",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluentflame-reader",
   "desktopName": "fluentflame-reader.desktop",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A modern desktop RSS reader given new life",
   "main": "./dist/electron.js",
   "scripts": {

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -31,13 +31,20 @@ if (!process.mas) {
     }
 }
 
-if (!app.isPackaged) {
-    // Critical for WM Class identification
-    app.setName("fluentflame-reader");
+if (app.isPackaged) {
+    // Force the userData path to use the proper internal name. This will vary for electron-builder
+    // applications depending on what the proposed "name" or "productName" will be, but we want
+    // this to be consistent for the packaged application.
+    const appDataPath = app.getPath("appData");
+    const internalAppName = "fluentflame-reader";
+    app.setPath("userData", `${appDataPath}/${internalAppName}`);
+    if (process.platform === "win32") {
+        app.setAppUserModelId("org.fluentflame.fluentflamereader");
+    }
+} else {
+    // Persist to using "Electron" for userData in development.
     app.setAppUserModelId(process.execPath);
 }
-else if (process.platform === "win32")
-    app.setAppUserModelId("org.fluentflame.fluentflamereader");
 
 let restarting = false;
 


### PR DESCRIPTION
This will revert back to previous setting behaviour, regardless what package.json has set for name or productName.

Additionally, remove the productName entry, as it wasn't actually needed for the desktop file association. The undocumented `desktopName` is what actually determines this, see:

https://github.com/electron-userland/electron-builder/issues/9103