### PR TITLE
Add default open target option

### DIFF
--- a/src/bridges/settings.ts
+++ b/src/bridges/settings.ts
@@ -3,6 +3,7 @@ import {
     ThemeSettings,
     SearchEngines,
     ServiceConfigs,
+    SourceOpenTarget,
     ViewConfig,
     AnimationMotionPref,
     ThumbnailTypePref,
@@ -95,6 +96,13 @@ const settingsBridge = {
     },
     setFont: (font: string) => {
         ipcRenderer.invoke("set-font", font);
+    },
+
+    getDefaultOpenTargetPref: (): Promise<SourceOpenTarget> => {
+        return ipcRenderer.invoke("get-default-open-target-pref");
+    },
+    setDefaultOpenTargetPref: (openTarget: SourceOpenTarget) => {
+        ipcRenderer.invoke("set-default-open-target-pref", openTarget);
     },
 
     getFetchInterval: (): number => {

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -12,14 +12,11 @@ import {
     Icon,
     Link,
 } from "@fluentui/react";
-import {
-    RSSSource,
-    SourceOpenTarget,
-    SourceTextDirection,
-} from "../scripts/models/source";
+import { RSSSource, SourceTextDirection } from "../scripts/models/source";
 import { shareSubmenu } from "./context-menu";
 import { platformCtrl, decodeFetchResponse } from "../scripts/utils";
 import { getAnimationMotionPref } from "../scripts/settings";
+import { SourceOpenTarget } from "../schema-types";
 
 const FONT_SIZE_OPTIONS = [12, 13, 14, 15, 16, 17, 18, 19, 20];
 

--- a/src/components/article.tsx
+++ b/src/components/article.tsx
@@ -22,6 +22,7 @@ const FONT_SIZE_OPTIONS = [12, 13, 14, 15, 16, 17, 18, 19, 20];
 
 type ArticleProps = {
     item: RSSItem;
+    defaultOpenTarget: SourceOpenTarget;
     source: RSSSource;
     locale: string;
     shortcuts: (item: RSSItem, e: KeyboardEvent) => void;
@@ -50,16 +51,25 @@ type ArticleState = {
     errorDescription: string;
 };
 
+function shouldLoad(props: ArticleProps, target: SourceOpenTarget) {
+    return (
+        props.source.openTarget === target ||
+        (props.source.openTarget === SourceOpenTarget.DeferToGlobal &&
+            props.defaultOpenTarget === target)
+    );
+}
+
 class Article extends React.Component<ArticleProps, ArticleState> {
     webview: Electron.WebviewTag;
 
     constructor(props: ArticleProps) {
         super(props);
+        const loadFull = shouldLoad(props, SourceOpenTarget.FullContent);
         this.state = {
             fontFamily: window.settings.getFont(),
             fontSize: window.settings.getFontSize(),
-            loadWebpage: props.source.openTarget === SourceOpenTarget.Webpage,
-            loadFull: props.source.openTarget === SourceOpenTarget.FullContent,
+            loadWebpage: shouldLoad(props, SourceOpenTarget.Webpage),
+            loadFull: loadFull,
             fullContent: "",
             loaded: false,
             error: false,
@@ -68,8 +78,7 @@ class Article extends React.Component<ArticleProps, ArticleState> {
         window.utils.addWebviewContextListener(this.contextMenuHandler);
         window.utils.addWebviewKeydownListener(this.keyDownHandler);
         window.utils.addWebviewErrorListener(this.webviewError);
-        if (props.source.openTarget === SourceOpenTarget.FullContent)
-            this.loadFull();
+        if (loadFull) this.loadFull();
     }
 
     setFontSize = (size: number) => {
@@ -285,15 +294,15 @@ class Article extends React.Component<ArticleProps, ArticleState> {
     };
     componentDidUpdate = (prevProps: ArticleProps) => {
         if (prevProps.item.iid != this.props.item.iid) {
+            const loadFull = shouldLoad(
+                this.props,
+                SourceOpenTarget.FullContent,
+            );
             this.setState({
-                loadWebpage:
-                    this.props.source.openTarget === SourceOpenTarget.Webpage,
-                loadFull:
-                    this.props.source.openTarget ===
-                    SourceOpenTarget.FullContent,
+                loadWebpage: shouldLoad(this.props, SourceOpenTarget.Webpage),
+                loadFull: loadFull,
             });
-            if (this.props.source.openTarget === SourceOpenTarget.FullContent)
-                this.loadFull();
+            if (loadFull) this.loadFull();
         }
         this.componentDidMount();
     };

--- a/src/components/cards/card.tsx
+++ b/src/components/cards/card.tsx
@@ -8,6 +8,7 @@ import { SourceOpenTarget, ViewConfig } from "../../schema-types";
 export namespace Card {
     export type Props = {
         feedId: string;
+        defaultOpenTarget: SourceOpenTarget;
         item: RSSItem;
         source: RSSSource;
         filter: FeedFilter;
@@ -33,17 +34,16 @@ export namespace Card {
     const onClick = (props: Props, e: React.MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
-        switch (props.source.openTarget) {
-            case SourceOpenTarget.External: {
-                openInBrowser(props, e);
-                break;
-            }
-            default: {
-                props.markRead(props.item);
-                props.showItem(props.feedId, props.item);
-                break;
-            }
+        if (
+            props.source.openTarget === SourceOpenTarget.External ||
+            (props.source.openTarget === SourceOpenTarget.DeferToGlobal &&
+                props.defaultOpenTarget === SourceOpenTarget.External)
+        ) {
+            openInBrowser(props, e);
+            return;
         }
+        props.markRead(props.item);
+        props.showItem(props.feedId, props.item);
     };
 
     const onMouseUp = (props: Props, e: React.MouseEvent) => {

--- a/src/components/cards/card.tsx
+++ b/src/components/cards/card.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { RSSSource, SourceOpenTarget } from "../../scripts/models/source";
+import { RSSSource } from "../../scripts/models/source";
 import { RSSItem } from "../../scripts/models/item";
 import { platformCtrl } from "../../scripts/utils";
 import { FeedFilter } from "../../scripts/models/feed";
-import { ViewConfig } from "../../schema-types";
+import { SourceOpenTarget, ViewConfig } from "../../schema-types";
 
 export namespace Card {
     export type Props = {

--- a/src/components/feeds/cards-feed.tsx
+++ b/src/components/feeds/cards-feed.tsx
@@ -54,6 +54,7 @@ class CardsFeed extends React.Component<FeedProps> {
         item ? (
             <DefaultCard
                 feedId={this.props.feed.iid}
+                defaultOpenTarget={this.props.defaultOpenTarget}
                 key={item.iid}
                 item={item}
                 source={this.props.sourceMap[item.source]}

--- a/src/components/feeds/feed.tsx
+++ b/src/components/feeds/feed.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { RSSItem } from "../../scripts/models/item";
 import { FeedReduxProps } from "../../containers/feed-container";
 import { RSSFeed, FeedFilter } from "../../scripts/models/feed";
-import { ViewType, ViewConfig } from "../../schema-types";
+import { SourceOpenTarget, ViewType, ViewConfig } from "../../schema-types";
 import CardsFeed from "./cards-feed";
 import ListFeed from "./list-feed";
 

--- a/src/components/feeds/feed.tsx
+++ b/src/components/feeds/feed.tsx
@@ -8,6 +8,7 @@ import ListFeed from "./list-feed";
 
 export type FeedProps = FeedReduxProps & {
     feed: RSSFeed;
+    defaultOpenTarget: SourceOpenTarget;
     viewType: ViewType;
     viewConfig?: ViewConfig;
     items: RSSItem[];

--- a/src/components/feeds/list-feed.tsx
+++ b/src/components/feeds/list-feed.tsx
@@ -19,6 +19,7 @@ class ListFeed extends React.Component<FeedProps> {
     onRenderItem = (item: RSSItem) => {
         const props = {
             feedId: this.props.feed.iid,
+            defaultOpenTarget: this.props.defaultOpenTarget,
             key: item.iid,
             item: item,
             source: this.props.sourceMap[item.source],

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -40,54 +40,45 @@ type AppTabProps = {
     importAll: () => Promise<void>;
 };
 
-type AppTabState = {
-    pacStatus: boolean;
-    pacUrl: string;
-    themeSettings: ThemeSettings;
-    itemSize: string;
-    cacheSize: string;
-    deleteIndex: string;
-};
+async function getCacheSize() {
+    const size = await window.utils.getCacheSize();
+    return byteToMB(size);
+}
+async function getItemSize() {
+    const size = await db.calculateItemSize();
+    return byteToMB(size);
+}
 
-class AppTab extends React.Component<AppTabProps, AppTabState> {
-    constructor(props: AppTabProps) {
-        super(props);
-        this.state = {
-            pacStatus: window.settings.getProxyStatus(),
-            pacUrl: window.settings.getProxy(),
-            themeSettings: getThemeSettings(),
-            itemSize: null,
-            cacheSize: null,
-            deleteIndex: null,
-        };
-        this.getItemSize();
-        this.getCacheSize();
-    }
+export default function AppTab(props: AppTabProps): React.JSX.Element {
+    const [themeSettingState, setThemeSettingState] =
+        React.useState(getThemeSettings());
+    const [itemSizeLabel, setItemSizeLabel] = React.useState<string | null>(
+        null,
+    );
+    const [cacheSizeLabel, setCacheSizeLabel] = React.useState<string | null>(
+        null,
+    );
+    const [deleteIndex, setDeleteIndex] = React.useState<string | null>(null);
 
-    getCacheSize = () => {
-        window.utils.getCacheSize().then((size) => {
-            this.setState({ cacheSize: byteToMB(size) });
-        });
-    };
-    getItemSize = () => {
-        db.calculateItemSize().then((size: number) => {
-            this.setState({ itemSize: byteToMB(size) });
-        });
+    React.useEffect(() => {
+        getItemSize().then((sizeLabel) => setItemSizeLabel(sizeLabel));
+        getCacheSize().then((sizeLabel) => setCacheSizeLabel(sizeLabel));
+    }, []);
+
+    const clearCache = async () => {
+        return window.utils
+            .clearCache()
+            .then(getCacheSize)
+            .then((sizeLabel) => setCacheSizeLabel(sizeLabel));
     };
 
-    clearCache = () => {
-        window.utils.clearCache().then(() => {
-            this.getCacheSize();
-        });
-    };
-
-    themeChoices = (): IChoiceGroupOption[] => [
+    const themeChoices = (): IChoiceGroupOption[] => [
         { key: ThemeSettings.Default, text: intl.get("followSystem") },
         { key: ThemeSettings.Light, text: intl.get("app.lightTheme") },
         { key: ThemeSettings.Dark, text: intl.get("app.darkTheme") },
     ];
 
-    fetchIntervalOptions = (): IDropdownOption[] => [
+    const fetchIntervalOptions = (): IDropdownOption[] => [
         { key: 0, text: intl.get("app.never") },
         { key: 10, text: intl.get("time.minute", { m: 10 }) },
         { key: 15, text: intl.get("time.minute", { m: 15 }) },
@@ -96,11 +87,11 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
         { key: 45, text: intl.get("time.minute", { m: 45 }) },
         { key: 60, text: intl.get("time.hour", { h: 1 }) },
     ];
-    onFetchIntervalChanged = (item: IDropdownOption) => {
-        this.props.setFetchInterval(item.key as number);
+    const onFetchIntervalChanged = (item: IDropdownOption) => {
+        props.setFetchInterval(item.key as number);
     };
 
-    searchEngineOptions = (): IDropdownOption[] =>
+    const searchEngineOptions = (): IDropdownOption[] =>
         [
             SearchEngines.Google,
             SearchEngines.Bing,
@@ -111,11 +102,11 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
             key: engine,
             text: getSearchEngineName(engine),
         }));
-    onSearchEngineChanged = (item: IDropdownOption) => {
+    const onSearchEngineChanged = (item: IDropdownOption) => {
         window.settings.setSearchEngine(item.key as number);
     };
 
-    deleteOptions = (): IDropdownOption[] => [
+    const deleteOptions = (): IDropdownOption[] => [
         { key: "7", text: intl.get("app.daysAgo", { days: 7 }) },
         { key: "14", text: intl.get("app.daysAgo", { days: 14 }) },
         { key: "21", text: intl.get("app.daysAgo", { days: 21 }) },
@@ -123,18 +114,19 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
         { key: "0", text: intl.get("app.deleteAll") },
     ];
 
-    deleteChange = (_, item: IDropdownOption) => {
-        this.setState({ deleteIndex: item ? String(item.key) : null });
+    const deleteChange = (_: any, item: IDropdownOption) => {
+        setDeleteIndex(item ? String(item.key) : null);
     };
 
-    confirmDelete = () => {
-        this.setState({ itemSize: null });
-        this.props
-            .deleteArticles(parseInt(this.state.deleteIndex))
-            .then(() => this.getItemSize());
+    const confirmDelete = async () => {
+        setItemSizeLabel(null);
+        return props
+            .deleteArticles(parseInt(deleteIndex))
+            .then(getItemSize)
+            .then((sizeLabel) => setItemSizeLabel(sizeLabel));
     };
 
-    languageOptions = (): IDropdownOption[] => [
+    const languageOptions = (): IDropdownOption[] => [
         { key: "default", text: intl.get("followSystem") },
         { key: "de", text: "Deutsch" },
         { key: "en-US", text: "English" },
@@ -156,21 +148,21 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
         { key: "zh-TW", text: "中文（繁體）" },
     ];
 
-    onThemeChange = (_, option: IChoiceGroupOption) => {
+    const onThemeChange = (_: any, option: IChoiceGroupOption) => {
         setThemeSettings(option.key as ThemeSettings);
-        this.setState({ themeSettings: option.key as ThemeSettings });
+        setThemeSettingState(option.key as ThemeSettings);
     };
 
-    render = () => (
+    return (
         <div className="tab-body">
             <Label>{intl.get("app.language")}</Label>
             <Stack horizontal>
                 <Stack.Item>
                     <Dropdown
                         defaultSelectedKey={window.settings.getLocaleSettings()}
-                        options={this.languageOptions()}
+                        options={languageOptions()}
                         onChanged={(option) =>
-                            this.props.setLanguage(String(option.key))
+                            props.setLanguage(String(option.key))
                         }
                         style={{ width: 200 }}
                     />
@@ -179,9 +171,9 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
 
             <ChoiceGroup
                 label={intl.get("app.theme")}
-                options={this.themeChoices()}
-                onChange={this.onThemeChange}
-                selectedKey={this.state.themeSettings}
+                options={themeChoices()}
+                onChange={onThemeChange}
+                selectedKey={themeSettingState}
             />
             <AnimationPreferences />
             <ThumbnailTypePreferences />
@@ -191,8 +183,8 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 <Stack.Item>
                     <Dropdown
                         defaultSelectedKey={window.settings.getFetchInterval()}
-                        options={this.fetchIntervalOptions()}
-                        onChanged={this.onFetchIntervalChanged}
+                        options={fetchIntervalOptions()}
+                        onChanged={onFetchIntervalChanged}
                         style={{ width: 200 }}
                     />
                 </Stack.Item>
@@ -203,8 +195,8 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 <Stack.Item>
                     <Dropdown
                         defaultSelectedKey={window.settings.getSearchEngine()}
-                        options={this.searchEngineOptions()}
-                        onChanged={this.onSearchEngineChanged}
+                        options={searchEngineOptions()}
+                        onChanged={onSearchEngineChanged}
                         style={{ width: 200 }}
                     />
                 </Stack.Item>
@@ -215,25 +207,24 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 <Stack.Item grow>
                     <Dropdown
                         placeholder={intl.get("app.deleteChoices")}
-                        options={this.deleteOptions()}
-                        selectedKey={this.state.deleteIndex}
-                        onChange={this.deleteChange}
+                        options={deleteOptions()}
+                        selectedKey={deleteIndex}
+                        onChange={deleteChange}
                     />
                 </Stack.Item>
                 <Stack.Item>
                     <DangerButton
                         disabled={
-                            this.state.itemSize === null ||
-                            this.state.deleteIndex === null
+                            itemSizeLabel === null || deleteIndex === null
                         }
                         text={intl.get("app.confirmDelete")}
-                        onClick={this.confirmDelete}
+                        onClick={confirmDelete}
                     />
                 </Stack.Item>
             </Stack>
             <span className="settings-hint up">
-                {this.state.itemSize
-                    ? intl.get("app.itemSize", { size: this.state.itemSize })
+                {itemSizeLabel
+                    ? intl.get("app.itemSize", { size: itemSizeLabel })
                     : intl.get("app.calculatingSize")}
             </span>
             <Stack horizontal>
@@ -241,16 +232,15 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                     <DefaultButton
                         text={intl.get("app.cache")}
                         disabled={
-                            this.state.cacheSize === null ||
-                            this.state.cacheSize === "0MB"
+                            cacheSizeLabel === null || cacheSizeLabel === "0MB"
                         }
-                        onClick={this.clearCache}
+                        onClick={clearCache}
                     />
                 </Stack.Item>
             </Stack>
             <span className="settings-hint up">
-                {this.state.cacheSize
-                    ? intl.get("app.cacheSize", { size: this.state.cacheSize })
+                {cacheSizeLabel
+                    ? intl.get("app.cacheSize", { size: cacheSizeLabel })
                     : intl.get("app.calculatingSize")}
             </span>
 
@@ -264,7 +254,7 @@ class AppTab extends React.Component<AppTabProps, AppTabState> {
                 </Stack.Item>
                 <Stack.Item>
                     <DefaultButton
-                        onClick={this.props.importAll}
+                        onClick={props.importAll}
                         text={intl.get("app.restore")}
                     />
                 </Stack.Item>
@@ -473,5 +463,3 @@ function ThumbnailTypePreferences() {
         </>
     );
 }
-
-export default AppTab;

--- a/src/components/settings/app.tsx
+++ b/src/components/settings/app.tsx
@@ -3,9 +3,15 @@ import * as db from "../../scripts/db";
 import intl from "react-intl-universal";
 import { urlTest, byteToMB, getSearchEngineName } from "../../scripts/utils";
 import {
+    RootState,
+    useAppDispatch,
+    useAppSelector,
+} from "../../scripts/reducer";
+import {
     AnimationMotionPref,
     ThemeSettings,
     SearchEngines,
+    SourceOpenTarget,
     ThumbnailTypePref,
 } from "../../schema-types";
 import {
@@ -13,12 +19,14 @@ import {
     setThemeSettings,
     getAnimationMotionPref,
     setAnimationMotionPref,
+    setDefaultOpenTargetPref,
     getNativeWindowFramePref,
     setNativeWindowFramePref,
     exportAll,
     getThumbnailTypePref,
     setThumbnailTypePref,
 } from "../../scripts/settings";
+import { SET_DEFAULT_OPEN_TARGET } from "../../scripts/models/app";
 import {
     ChoiceGroup,
     DefaultButton,
@@ -49,7 +57,13 @@ async function getItemSize() {
     return byteToMB(size);
 }
 
+function useDefaultOpenTarget(state: RootState) {
+    return state.app.defaultOpenTarget;
+}
+
 export default function AppTab(props: AppTabProps): React.JSX.Element {
+    const dispatch = useAppDispatch();
+
     const [themeSettingState, setThemeSettingState] =
         React.useState(getThemeSettings());
     const [itemSizeLabel, setItemSizeLabel] = React.useState<string | null>(
@@ -59,6 +73,7 @@ export default function AppTab(props: AppTabProps): React.JSX.Element {
         null,
     );
     const [deleteIndex, setDeleteIndex] = React.useState<string | null>(null);
+    const defaultOpenTarget = useAppSelector(useDefaultOpenTarget);
 
     React.useEffect(() => {
         getItemSize().then((sizeLabel) => setItemSizeLabel(sizeLabel));
@@ -153,6 +168,25 @@ export default function AppTab(props: AppTabProps): React.JSX.Element {
         setThemeSettingState(option.key as ThemeSettings);
     };
 
+    const defaultOpenTargetOptions = [
+        { key: SourceOpenTarget.Local, text: intl.get("sources.rssText") },
+        {
+            key: SourceOpenTarget.FullContent,
+            text: intl.get("article.loadFull"),
+        },
+        {
+            key: SourceOpenTarget.Webpage,
+            text: intl.get("sources.loadWebpage"),
+        },
+        { key: SourceOpenTarget.External, text: intl.get("openExternal") },
+    ];
+
+    const onDefaultOpenTargetChange = (_: any, option: IDropdownOption) => {
+        const optionKey = option.key as SourceOpenTarget;
+        setDefaultOpenTargetPref(optionKey);
+        dispatch({ type: SET_DEFAULT_OPEN_TARGET, value: optionKey });
+    };
+
     return (
         <div className="tab-body">
             <Label>{intl.get("app.language")}</Label>
@@ -178,6 +212,17 @@ export default function AppTab(props: AppTabProps): React.JSX.Element {
             <AnimationPreferences />
             <ThumbnailTypePreferences />
             <NativeWindowFramePreference />
+            <Label>{intl.get("app.defaultOpenTarget")}</Label>
+            <Stack horizontal>
+                <Stack.Item>
+                    <Dropdown
+                        defaultSelectedKey={defaultOpenTarget}
+                        options={defaultOpenTargetOptions}
+                        onChange={onDefaultOpenTargetChange}
+                        style={{ width: 200 }}
+                    />
+                </Stack.Item>
+            </Stack>
             <Label>{intl.get("app.fetchInterval")}</Label>
             <Stack horizontal>
                 <Stack.Item>

--- a/src/components/settings/sources.tsx
+++ b/src/components/settings/sources.tsx
@@ -161,6 +161,10 @@ class SourcesTab extends React.Component<SourcesTabProps, SourcesTabState> {
 
     sourceOpenTargetChoices = (): IChoiceGroupOption[] => [
         {
+            key: String(SourceOpenTarget.DeferToGlobal),
+            text: intl.get("default"),
+        },
+        {
             key: String(SourceOpenTarget.Local),
             text: intl.get("sources.rssText"),
         },

--- a/src/components/settings/sources.tsx
+++ b/src/components/settings/sources.tsx
@@ -18,11 +18,8 @@ import {
     MessageBarType,
     Toggle,
 } from "@fluentui/react";
-import {
-    SourceState,
-    RSSSource,
-    SourceOpenTarget,
-} from "../../scripts/models/source";
+import { SourceState, RSSSource } from "../../scripts/models/source";
+import { SourceOpenTarget } from "../../schema-types";
 import { urlTest } from "../../scripts/utils";
 import DangerButton from "../utils/danger-button";
 

--- a/src/containers/article-container.tsx
+++ b/src/containers/article-container.tsx
@@ -32,14 +32,16 @@ const getItem = (state: RootState, props: ArticleContainerProps) =>
 const getSource = (state: RootState, props: ArticleContainerProps) =>
     state.sources[state.items[props.itemId].source];
 const getLocale = (state: RootState) => state.app.locale;
+const getDefaultOpenTarget = (state: RootState) => state.app.defaultOpenTarget;
 
 const makeMapStateToProps = () => {
     return createSelector(
-        [getItem, getSource, getLocale],
-        (item, source, locale) => ({
+        [getItem, getSource, getLocale, getDefaultOpenTarget],
+        (item, source, locale, defaultOpenTarget) => ({
             item: item,
             source: source,
             locale: locale,
+            defaultOpenTarget: defaultOpenTarget,
         }),
     );
 };

--- a/src/containers/feed-container.tsx
+++ b/src/containers/feed-container.tsx
@@ -20,6 +20,7 @@ const getFeed = (state: RootState, props: FeedContainerProps) =>
 const getFilter = (state: RootState) => state.page.filter;
 const getViewConfig = (state: RootState) => state.page.viewConfig;
 const getCurrentItem = (state: RootState) => state.page.itemId;
+const getDefaultOpenTarget = (state: RootState) => state.app.defaultOpenTarget;
 
 const makeMapStateToProps = () => {
     return createSelector(
@@ -30,8 +31,18 @@ const makeMapStateToProps = () => {
             getFilter,
             getViewConfig,
             getCurrentItem,
+            getDefaultOpenTarget,
         ],
-        (sources, items, feed, filter, viewConfig, currentItem) => ({
+        (
+            sources,
+            items,
+            feed,
+            filter,
+            viewConfig,
+            currentItem,
+            defaultOpenTarget,
+        ) => ({
+            defaultOpenTarget: defaultOpenTarget,
             feed: feed,
             items: feed.iids.map((iid) => items[iid]),
             sourceMap: sources,

--- a/src/containers/settings/sources-container.tsx
+++ b/src/containers/settings/sources-container.tsx
@@ -8,7 +8,6 @@ import {
     RSSSource,
     updateSource,
     deleteSource,
-    SourceOpenTarget,
     deleteSources,
     toggleSourceHidden,
 } from "../../scripts/models/source";
@@ -16,7 +15,7 @@ import { importOPML, exportOPML } from "../../scripts/models/group";
 import { AppDispatch, validateFavicon } from "../../scripts/utils";
 import { saveSettings, toggleSettings } from "../../scripts/models/app";
 import { fetchItems } from "../../scripts/models/item";
-import { SyncService } from "../../schema-types";
+import { SyncService, SourceOpenTarget } from "../../schema-types";
 
 const getSources = (state: RootState) => state.sources;
 const getServiceOn = (state: RootState) =>

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -170,9 +170,12 @@ const DEFAULT_OPEN_TARGET_STORE_KEY = "defaultOpenTarget";
 ipcMain.handle("get-default-open-target-pref", () => {
     return store.get(DEFAULT_OPEN_TARGET_STORE_KEY, SourceOpenTarget.Local);
 });
-ipcMain.handle("set-default-open-target-pref", (_, openTarget: SourceOpenTarget) => {
-    store.set(DEFAULT_OPEN_TARGET_STORE_KEY, openTarget);
-});
+ipcMain.handle(
+    "set-default-open-target-pref",
+    (_, openTarget: SourceOpenTarget) => {
+        store.set(DEFAULT_OPEN_TARGET_STORE_KEY, openTarget);
+    },
+);
 
 const FETCH_INTEVAL_STORE_KEY = "fetchInterval";
 ipcMain.on("get-fetch-interval", (event) => {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -7,6 +7,7 @@ import {
     SearchEngines,
     SyncService,
     ServiceConfigs,
+    SourceOpenTarget,
     ViewConfig,
     ThumbnailTypePref,
     defaultViewConfig,
@@ -163,6 +164,14 @@ ipcMain.on("get-all-settings", (event) => {
         output[key] = value;
     }
     event.returnValue = output;
+});
+
+const DEFAULT_OPEN_TARGET_STORE_KEY = "defaultOpenTarget";
+ipcMain.handle("get-default-open-target-pref", () => {
+    return store.get(DEFAULT_OPEN_TARGET_STORE_KEY, SourceOpenTarget.Local);
+});
+ipcMain.handle("set-default-open-target-pref", (_, openTarget: SourceOpenTarget) => {
+    store.set(DEFAULT_OPEN_TARGET_STORE_KEY, openTarget);
 });
 
 const FETCH_INTEVAL_STORE_KEY = "fetchInterval";

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -71,6 +71,14 @@ export enum ThumbnailTypePref {
     Other = "other",
 }
 
+export const enum SourceOpenTarget {
+    Local = 0,
+    Webpage = 1,
+    External = 2,
+    FullContent = 3,
+    DeferToGlobal = 255,
+}
+
 export const enum SearchEngines {
     Google,
     Bing,
@@ -127,6 +135,7 @@ export type SchemaTypes = {
     fontSize: number;
     fontFamily: string;
     menuOn: boolean;
+    defaultOpenTarget: SourceOpenTarget;
     fetchInterval: number;
     searchEngine: SearchEngines;
     serviceConfigs: ServiceConfigs;

--- a/src/scripts/db.ts
+++ b/src/scripts/db.ts
@@ -69,6 +69,14 @@ fluentDB
     })
     .upgrade(migrateServiceRef);
 
+fluentDB
+    .version(8)
+    .stores({
+        sources: `++sid, &url`,
+        items: `++iid, source, date, serviceRef`,
+    })
+    .upgrade(migrateOpenTarget);
+
 export async function calculateItemSize(): Promise<number> {
     await fluentDB.open();
     let result = 0;
@@ -243,6 +251,22 @@ async function migrateServiceRef(
         });
 }
 
+async function migrateOpenTarget(
+    trans: Transaction & {
+        sources: Dexie.Table<SourceEntry, "sid">;
+        items: Dexie.Table<ItemEntry, "iid">;
+    },
+) {
+    return trans
+        .table("sources")
+        .toCollection()
+        .modify((source: SourceEntry) => {
+            if (source.openTarget === 0) {
+                // 255 is reserved for DeferToGlobal.
+                source.openTarget = 255;
+            }
+        });
+}
 // ------------------------------------------------------------------------------------------------
 // Utils
 // ------------------------------------------------------------------------------------------------

--- a/src/scripts/i18n/en-US.json
+++ b/src/scripts/i18n/en-US.json
@@ -229,6 +229,7 @@
         "deleteChoices": "Delete articles from ... days ago",
         "confirmDelete": "Delete",
         "daysAgo": "{days, plural, =1 {# day} other {# days}} ago",
+        "defaultOpenTarget": "Default open target for all articles",
         "deleteAll": "Delete all articles",
         "calculatingSize": "Calculating size...",
         "itemSize": "Around {size} of local storage is occupied by articles",

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -6,7 +6,6 @@ import {
     UPDATE_SOURCE,
     DELETE_SOURCE,
     initSources,
-    SourceOpenTarget,
     updateFavicon,
 } from "./source";
 import { RSSItem, ItemActionTypes, FETCH_ITEMS, fetchItems } from "./item";
@@ -34,6 +33,9 @@ import {
 } from "../settings";
 import locales from "../i18n/_locales";
 import { SYNC_SERVICE, ServiceActionTypes } from "./service";
+import {
+    SourceOpenTarget
+} from "../../schema-types";
 
 export const enum ContextMenuType {
     Hidden,
@@ -85,6 +87,7 @@ export class AppState {
     menu = getWindowBreakpoint() && window.settings.getDefaultMenu();
     menuKey = ALL;
     title = "";
+    defaultOpenTarget = SourceOpenTarget.Local;
     addSourceModal = {
         display: false,
     };
@@ -194,6 +197,7 @@ export const TOGGLE_SETTINGS = "TOGGLE_SETTINGS";
 export const SET_SETTINGS_TAB = "SET_SETTINGS_TAB";
 export const SAVE_SETTINGS = "SAVE_SETTINGS";
 export const FREE_MEMORY = "FREE_MEMORY";
+export const SET_DEFAULT_OPEN_TARGET = "SET_DEFAULT_OPEN_TARGET";
 
 interface ToggleSettingsAction {
     type: typeof TOGGLE_SETTINGS;
@@ -212,8 +216,13 @@ interface FreeMemoryAction {
     type: typeof FREE_MEMORY;
     iids: Set<number>;
 }
+interface SetDefaultOpenTargetAction {
+    type: typeof SET_DEFAULT_OPEN_TARGET;
+    value: SourceOpenTarget;
+}
 export type SettingsActionTypes =
     | ToggleSettingsAction
+    | SetDefaultOpenTargetAction
     | SetSettingsTabAction
     | SaveSettingsAction
     | FreeMemoryAction;
@@ -440,6 +449,8 @@ export function initApp(): AppThunk {
         dispatch(initIntl())
             .then(async () => {
                 if (window.utils.platform === "darwin") initTouchBarWithTexts();
+                const defaultOpenTarget = await window.settings.getDefaultOpenTargetPref();
+                dispatch({ type: SET_DEFAULT_OPEN_TARGET, value: defaultOpenTarget });
                 await dispatch(initSources());
             })
             .then(() => dispatch(initFeeds()))
@@ -748,6 +759,11 @@ export function appReducer(
                     ...state.settings,
                     tab: action.tab,
                 },
+            };
+        case SET_DEFAULT_OPEN_TARGET:
+            return {
+                ...state,
+                defaultOpenTarget: action.value,
             };
         case TOGGLE_LOGS:
             return {

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -33,9 +33,7 @@ import {
 } from "../settings";
 import locales from "../i18n/_locales";
 import { SYNC_SERVICE, ServiceActionTypes } from "./service";
-import {
-    SourceOpenTarget
-} from "../../schema-types";
+import { SourceOpenTarget } from "../../schema-types";
 
 export const enum ContextMenuType {
     Hidden,
@@ -449,8 +447,12 @@ export function initApp(): AppThunk {
         dispatch(initIntl())
             .then(async () => {
                 if (window.utils.platform === "darwin") initTouchBarWithTexts();
-                const defaultOpenTarget = await window.settings.getDefaultOpenTargetPref();
-                dispatch({ type: SET_DEFAULT_OPEN_TARGET, value: defaultOpenTarget });
+                const defaultOpenTarget =
+                    await window.settings.getDefaultOpenTargetPref();
+                dispatch({
+                    type: SET_DEFAULT_OPEN_TARGET,
+                    value: defaultOpenTarget,
+                });
                 await dispatch(initSources());
             })
             .then(() => dispatch(initFeeds()))

--- a/src/scripts/models/app.ts
+++ b/src/scripts/models/app.ts
@@ -763,6 +763,10 @@ export function appReducer(
                 },
             };
         case SET_DEFAULT_OPEN_TARGET:
+            if (action.value === SourceOpenTarget.DeferToGlobal) {
+                // This is invalid, this _IS_ the global state.
+                return state;
+            }
             return {
                 ...state,
                 defaultOpenTarget: action.value,

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -50,7 +50,7 @@ export class RSSSource {
     constructor(url: string, name: string = null) {
         this.url = url;
         this.name = name;
-        this.openTarget = SourceOpenTarget.Local;
+        this.openTarget = SourceOpenTarget.DeferToGlobal;
         this.lastFetched = new Date();
         this.fetchFrequency = 0;
         this.textDir = SourceTextDirection.LTR;

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -21,13 +21,7 @@ import { selectAllArticles } from "./page";
 import { initFeeds } from "./feed";
 import { SourceRule } from "./rule";
 import { fixBrokenGroups } from "./group";
-
-export const enum SourceOpenTarget {
-    Local,
-    Webpage,
-    External,
-    FullContent,
-}
+import { SourceOpenTarget } from "../../schema-types";
 
 export const enum SourceTextDirection {
     LTR,

--- a/src/scripts/settings.ts
+++ b/src/scripts/settings.ts
@@ -6,6 +6,7 @@ import locales from "./i18n/_locales";
 import {
     AnimationMotionPref,
     ListViewConfigs,
+    SourceOpenTarget,
     ThemeSettings,
     ThumbnailTypePref,
     ViewConfig,
@@ -110,6 +111,12 @@ export function getNativeWindowFramePref(): boolean {
 export function setNativeWindowFramePref(pref: boolean) {
     return window.settings.setNativeWindowFramePref(pref);
 }
+export function getDefaultOpenTargetPref(): Promise<SourceOpenTarget> {
+    return window.settings.getDefaultOpenTargetPref();
+}
+export function setDefaultOpenTargetPref(pref: SourceOpenTarget) {
+    window.settings.setDefaultOpenTargetPref(pref);
+}
 export function hasWindowFrame() {
     return (
         window.utils.platform === "darwin" ||
@@ -199,6 +206,7 @@ export interface FluentflameSettingConfig {
     database: DatabaseConfig;
     filterType: number;
     menuOn: boolean;
+    defaultOpenTarget: SourceOpenTarget;
     useNativeWindowFramePref: boolean;
     sourceGroups: any[];
     view?: number; // Deprecated.
@@ -269,6 +277,7 @@ function migrateExport(input: any): FluentflameSettingConfig {
         },
         filterType: input.filterType ?? 0,
         menuOn: input.menuOn ?? false,
+        defaultOpenTarget: input.defaultOpenTarget ?? SourceOpenTarget.Local,
         useNativeWindowFramePref: input.useNativeWindowFramePref ?? false,
         sourceGroups: input.sourceGroups ?? [],
         viewConfig: {


### PR DESCRIPTION
This intends to implement #157.

This also comes along with a functional rewrite of the `AppTab`, as well as changes to the state + a migration plan
for the versions.

- Adds new `defaultOpenTarget` settings option in preferences
- Migrates existing feeds that have `Local` as their `openTarget` to `DeferToGlobal` (you can always switch back in settings)
- Adds a new section in app start up to get initial window settings for `defaultOpenTarget`
- Moved SourceOpenTarget to schema-types.

<img width="651" height="213" alt="image" src="https://github.com/user-attachments/assets/61f9f3a3-904a-4a82-82c9-fe0bb2ad30e4" />
