### PR TITLE
Allow cached-img to guess image content-type

### DIFF
--- a/src/components/cards/cached-img.tsx
+++ b/src/components/cards/cached-img.tsx
@@ -43,7 +43,7 @@ class CachedImg extends React.Component<ImgProps> {
         if (!url) return "";
         const response = await fetch(url, { method: "HEAD" });
         if (!response.ok) return "";
-        return response.headers.get("content-type");
+        return response.headers.get("content-type") ?? "";
     }
 
     private async loadImage(url: string): Promise<VideoFrame[]> {
@@ -51,7 +51,8 @@ class CachedImg extends React.Component<ImgProps> {
             const response = await fetch(url);
             if (!response.ok) return null;
             const data = await response.bytes();
-            const contentType = response.headers.get("content-type");
+            const contentType: string =
+                response.headers.get("content-type") ?? "";
             if (!ImageDecoder.isTypeSupported(contentType)) return null;
             const decoder = new ImageDecoder({ data, type: contentType });
             let frameIndex = 0;
@@ -154,14 +155,16 @@ class CachedImg extends React.Component<ImgProps> {
             if (imgSource === placeholderImageSource) {
                 await new Promise((resolve) => setTimeout(resolve, 100));
                 this.forceUpdate();
-            } else this._imgSource = imgSource;
+            } else {
+                this._imgSource = imgSource;
+            }
         } else {
             CachedImg._cache.set(this.props.src, placeholderImageSource);
             const contentType = await this.loadContentType(this.props.src);
             if (contentType.startsWith("video/")) {
                 this._imgSource = this.createVideo(this.props.src);
             } else if (
-                //potentially animated images
+                // potentially animated images
                 [
                     "image/gif",
                     "image/webp",
@@ -176,9 +179,20 @@ class CachedImg extends React.Component<ImgProps> {
                     this.draw(imgSource[0]);
                     const img = this._canvasRef.current.toDataURL();
                     this._imgSource = this.createImage(img);
-                } else this._imgSource = imgSource;
-            } else if (contentType !== "") {
-                this._imgSource = this.createImage(this.props.src);
+                } else {
+                    this._imgSource = imgSource;
+                }
+            } else {
+                // Assume it's a static image. This may fail but that's okay.
+                try {
+                    this._imgSource = this.createImage(this.props.src);
+                } catch (e) {
+                    this._imgSource = null;
+                    console.warn(
+                        `Error while rendering image from ${this.props.src}:`,
+                        e,
+                    );
+                }
             }
             CachedImg._cache.set(this.props.src, this._imgSource);
         }


### PR DESCRIPTION
Some responses from opengraph embeds don't announce their content types. This is annoying, but since we are checking that this is an actual opengraph embed, we can assume it's some sort of image... probably.

Example feed that the current patch code on:
https://haskellforall.com/rss.xml