### PR TITLE
Faster thumbs

### DIFF
--- a/src/components/cards/cached-img.tsx
+++ b/src/components/cards/cached-img.tsx
@@ -32,6 +32,7 @@ class CachedImg extends React.Component<ImgProps> {
     private _requestVideoFrameCallback: number | null = null;
     private _maxCanvasWidth: number;
     private _maxCanvasHeight: number;
+    private _failed: boolean = false;
 
     constructor(props: ImgProps) {
         super(props);
@@ -70,8 +71,8 @@ class CachedImg extends React.Component<ImgProps> {
                 }
             }
             return frames;
-        } catch {
-            console.log(`Failed to fetch ${url}`);
+        } catch (e) {
+            console.warn(`Failed to fetch ${url} for thumb load`, e);
             return null;
         }
     }
@@ -188,21 +189,31 @@ class CachedImg extends React.Component<ImgProps> {
                     this._imgSource = this.createImage(this.props.src);
                 } catch (e) {
                     this._imgSource = null;
+                    this._failed = true;
                     console.warn(
-                        `Error while rendering image from ${this.props.src}:`,
+                        `Failed to create image element from ${this.props.src}:`,
                         e,
                     );
+                    this.forceUpdate();
+                    return;
                 }
             }
             CachedImg._cache.set(this.props.src, this._imgSource);
         }
-        if (this._imgSource !== null) {
+        if (this._imgSource !== null && !this._failed) {
             if (this._imgSource instanceof HTMLImageElement) {
                 try {
                     await this._imgSource.decode();
                     this.draw(this._imgSource);
-                } catch {
+                } catch (e) {
+                    this._imgSource = null;
+                    this._failed = true;
+                    console.warn(
+                        `Failed to decode image from ${this.props.src}:`,
+                        e,
+                    );
                     this.forceUpdate();
+                    return;
                 }
             } else if (this._imgSource instanceof HTMLVideoElement) {
                 const video = this._imgSource;
@@ -266,6 +277,11 @@ class CachedImg extends React.Component<ImgProps> {
     }
 
     render(): React.ReactNode {
+        if (this._failed) {
+            // If we failed somewhere during a previous render,
+            // give up immediately.
+            return null;
+        }
         const canvas = (
             <canvas
                 className={this.props.className}

--- a/src/schema-types.ts
+++ b/src/schema-types.ts
@@ -5,7 +5,7 @@ export class SourceGroup {
     expanded?: boolean;
     index?: number; // available only from menu or groups tab container
 
-    constructor(sids: number[], name: string = null) {
+    constructor(sids: number[], name?: string) {
         name = (name && name.trim()) || "Source group";
         if (sids.length == 1) {
             this.isMultiple = false;

--- a/src/scripts/fetch-pool.ts
+++ b/src/scripts/fetch-pool.ts
@@ -14,6 +14,29 @@ export class Pool {
         this.__started = false;
         this.__available = Math.min(available, total);
     }
+
+    /** Fetch from this pool. Used for rate limiting.
+     *
+     * @param resource: Resource path to gather.
+     * @param init: RequestInit to forward to fetch.
+     * @param timeout: Timeout after which to kill the fetch attempt.
+     * @param pool: Pool to pull from (defaults to global fetch pool).
+     */
+    async fetch(
+        resource: string | URL | Request,
+        init?: RequestInit,
+        timeout?: number,
+    ): Promise<Response> {
+        if (!this.__started) {
+            throw new Error("Pool not started, did you run `startPool` first?");
+        }
+        if (this.__available >= 1) {
+            return uncheckedFetch(resource, init, this);
+        } else {
+            await pollAvailable(this, timeout);
+            return uncheckedFetch(resource, init, this);
+        }
+    }
 }
 
 export const GLOBAL_FETCH_POOL = new Pool(30, 30, 30);
@@ -74,28 +97,4 @@ function pollAvailable(pool: Pool = GLOBAL_FETCH_POOL, timeout?: number) {
     return new Promise<void>((resolve, reject) => {
         internal(resolve, reject);
     });
-}
-
-/** Fetch from a given pool. Used for rate limiting.
- *
- * @param resource: Resource path to gather.
- * @param init: RequestInit to forward to fetch.
- * @param timeout: Timeout after which to kill the fetch attempt.
- * @param pool: Pool to pull from (defaults to global fetch pool).
- */
-export async function fetchPool(
-    resource: string | URL | Request,
-    init: RequestInit,
-    timeout?: number,
-    pool: Pool = GLOBAL_FETCH_POOL,
-): Promise<Response> {
-    if (!pool.__started) {
-        throw new Error("Pool not started, did you run `startPool` first?");
-    }
-    if (pool.__available >= 1) {
-        return uncheckedFetch(resource, init, pool);
-    } else {
-        await pollAvailable(pool, timeout);
-        return uncheckedFetch(resource, init, pool);
-    }
 }

--- a/src/scripts/fetch-pool.ts
+++ b/src/scripts/fetch-pool.ts
@@ -1,35 +1,50 @@
-export type Pool = {
+/** PoolTimeout type to use for stopPool. */
+export type PoolTimeout = {};
+
+export class Pool {
     total: number;
     refill_rate: number;
     __started: boolean;
     __available: number;
-};
+    __timeout?: PoolTimeout;
 
-export const GLOBAL_FETCH_POOL: Pool = {
-    total: 30, // Per second.
-    refill_rate: 30, // Per second.
-    __started: false,
-    __available: 30,
-};
+    constructor(total: number, refill_rate: number, available: number = 0) {
+        this.total = total;
+        this.refill_rate = refill_rate;
+        this.__started = false;
+        this.__available = Math.min(available, total);
+    }
+}
 
-/** PoolTimeout type to use for stopPool. */
-export type PoolTimeout = {};
+export const GLOBAL_FETCH_POOL = new Pool(30, 30, 30);
 
 /** Start a pool filling interval. */
-export function startPool(pool: Pool = GLOBAL_FETCH_POOL): PoolTimeout {
+export function startPool(
+    pool: Pool = GLOBAL_FETCH_POOL,
+    startAmnt: number | undefined = undefined,
+): Pool {
+    if (pool.__started) {
+        return pool;
+    }
     pool.__started = true;
+    if (startAmnt !== undefined) {
+        pool.__available = Math.min(startAmnt, pool.total);
+    }
     const internal = () => {
         pool.__available = Math.min(
-            pool.__available + pool.refill_rate / 4,
+            pool.__available + pool.refill_rate / 2,
             pool.total,
         );
     };
-    return setInterval(internal, 1000 / 4) as unknown as PoolTimeout;
+    const timeout = setInterval(internal, 1000 / 2) as unknown as PoolTimeout;
+    pool.__timeout = timeout;
+    return pool;
 }
 
 /** Stop the pool filling. */
-export function stopPool(poolTimeout: PoolTimeout) {
-    return clearInterval(poolTimeout as unknown as any);
+export function stopPool(pool: Pool) {
+    pool.__started = false;
+    return clearInterval(pool.__timeout as unknown as any);
 }
 
 function uncheckedFetch(

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -1,6 +1,6 @@
 import { fluentDB } from "../db";
 import intl from "react-intl-universal";
-import type { MyParserItem } from "../utils";
+import { type MyParserItem, timeoutPromise } from "../utils";
 import {
     type ThumbnailAttributes,
     generateThumbnailAttrList,
@@ -36,6 +36,7 @@ export class RSSItem {
     fetchedDate: Date;
     thumb?: string;
     thumbnails?: ThumbnailAttributes[];
+    thumbnailJobs?: Promise<ThumbnailAttributes[]>[];
     content: string;
     snippet: string;
     creator?: string;
@@ -55,6 +56,8 @@ export class RSSItem {
         this.link = item.link || "";
         this.fetchedDate = new Date();
         this.date = new Date(item.isoDate ?? item.pubDate ?? this.fetchedDate);
+        this.thumbnails = [];
+        this.thumbnailJobs = [];
         this.creator = item.creator;
         this.hasRead = false;
         this.starred = false;
@@ -110,7 +113,7 @@ export class RSSItem {
             item.content = parsed.content || "";
             item.snippet = htmlDecode(parsed.contentSnippet || "");
         }
-        item.thumbnails = await generateThumbnailAttrList({
+        item.thumbnailJobs = generateThumbnailAttrList({
             targetLink: item.link,
             mediaThumbnails: parsed.mediaThumbnails,
             mediaContent: parsed.mediaContent,
@@ -119,7 +122,9 @@ export class RSSItem {
             parsedImage: parsed.image,
             content: parsed.content,
         });
-        item.thumb = item.thumbnails?.at(0)?.url;
+        // Ensure we don't spend more than 1 second on loading the thumbnails.
+        const jobsComplete = Promise.allSettled(item.thumbnailJobs);
+        await Promise.race([jobsComplete, timeoutPromise(1000)]);
     }
 }
 
@@ -127,12 +132,19 @@ export type ItemState = {
     [iid: number]: RSSItem;
 };
 
+export const ADD_ITEM_THUMBNAILS = "ADD_ITEM_THUMBNAILS";
 export const FETCH_ITEMS = "FETCH_ITEMS";
 export const MARK_READ = "MARK_READ";
 export const MARK_ALL_READ = "MARK_ALL_READ";
 export const MARK_UNREAD = "MARK_UNREAD";
 export const TOGGLE_STARRED = "TOGGLE_STARRED";
 export const TOGGLE_HIDDEN = "TOGGLE_HIDDEN";
+
+interface AddItemThumbnails {
+    type: typeof ADD_ITEM_THUMBNAILS;
+    item: RSSItem;
+    thumbnails: ThumbnailAttributes[];
+}
 
 interface FetchItemsAction {
     type: typeof FETCH_ITEMS;
@@ -172,12 +184,60 @@ interface ToggleHiddenAction {
 }
 
 export type ItemActionTypes =
+    | AddItemThumbnails
     | FetchItemsAction
     | MarkReadAction
     | MarkAllReadAction
     | MarkUnreadAction
     | ToggleStarredAction
     | ToggleHiddenAction;
+
+export function addItemThumbnails(
+    item: RSSItem,
+    thumbnails: ThumbnailAttributes[],
+) {
+    return {
+        type: ADD_ITEM_THUMBNAILS,
+        item: item,
+        thumbnails: thumbnails,
+    };
+}
+
+/**
+ * Dispatch state updates on each thumbnail job completion.
+ *
+ * Specifically, this assumes that the passed in item has
+ * already started its thumbnailJobs list. It then attaches
+ * promises to each job which updates the Redux state and
+ * database accordingly.
+ */
+export function attachToThumbnailJobs(item: RSSItem) {
+    return (dispatch: any, _: any) =>
+        item.thumbnailJobs.map(async (promise) => {
+            const result = await promise;
+
+            if (result.length === 0) {
+                return result;
+            }
+            if (item.iid === undefined) {
+                const msg = `iid is undefined for ${item.link} during thumbnail update`;
+                console.error(msg);
+                throw Error(msg);
+            }
+
+            if (item.thumbnails?.length > 0) {
+                item.thumbnails = [...item.thumbnails, ...result];
+            } else {
+                item.thumbnails = result;
+            }
+            item.thumb = item.thumb ?? result?.at(0)?.url;
+            await Promise.all([
+                updateItemInDB(item, { thumbnails: item.thumbnails }),
+                dispatch(addItemThumbnails(item, result)),
+            ]);
+            return result;
+        });
+}
 
 export function fetchItemsRequest(fetchCount = 0): ItemActionTypes {
     return {
@@ -261,11 +321,23 @@ export function fetchItems(
                           .filter((s) => !s.serviceRef);
             for (let source of sources) {
                 let promise = RSSSource.fetchItems(source);
-                promise.then(() =>
-                    dispatch(
-                        updateSource({ ...source, lastFetched: new Date() }),
-                    ),
-                );
+                promise
+                    .then(async (items) => {
+                        for (const item of items) {
+                            // Don't await on these, these could take some
+                            // time and they can dispatch independently.
+                            dispatch(attachToThumbnailJobs(item));
+                        }
+                        return items;
+                    })
+                    .then(() =>
+                        dispatch(
+                            updateSource({
+                                ...source,
+                                lastFetched: new Date(),
+                            }),
+                        ),
+                    );
                 promise.finally(() => dispatch(fetchItemsIntermediate()));
                 promises.push(promise);
             }
@@ -508,6 +580,13 @@ export function itemReducer(
         | SettingsActionTypes,
 ): ItemState {
     switch (action.type) {
+        case ADD_ITEM_THUMBNAILS:
+            const nextItem = { ...state[action.item.iid] };
+            nextItem.thumbnails = [
+                ...action.thumbnails,
+                ...(nextItem.thumbnails ?? []),
+            ];
+            return { ...state, [action.item.iid]: nextItem };
         case FETCH_ITEMS:
             switch (action.status) {
                 case ActionStatus.Success: {

--- a/src/scripts/models/item.ts
+++ b/src/scripts/models/item.ts
@@ -1,4 +1,4 @@
-import { fluentDB } from "../db";
+import { type ItemEntry, fluentDB } from "../db";
 import intl from "react-intl-universal";
 import { type MyParserItem, timeoutPromise } from "../utils";
 import {
@@ -225,7 +225,7 @@ export function attachToThumbnailJobs(item: RSSItem) {
                 throw Error(msg);
             }
 
-            if (item.thumbnails?.length > 0) {
+            if (item.thumbnails && item.thumbnails.length > 0) {
                 item.thumbnails = [...item.thumbnails, ...result];
             } else {
                 item.thumbnails = result;
@@ -259,7 +259,10 @@ export function fetchItemsSuccess(
     };
 }
 
-export function fetchItemsFailure(source: RSSSource, err): ItemActionTypes {
+export function fetchItemsFailure(
+    source: RSSSource,
+    err: any,
+): ItemActionTypes {
     return {
         type: FETCH_ITEMS,
         status: ActionStatus.Failure,
@@ -276,8 +279,28 @@ export function fetchItemsIntermediate(): ItemActionTypes {
 }
 
 export async function insertItems(items: RSSItem[]): Promise<RSSItem[]> {
-    items.sort((a, b) => a.date.getTime() - b.date.getTime());
-    const keys = await fluentDB.items.bulkAdd(items, { allKeys: true });
+    const entries: ItemEntry[] = items
+        .sort((a, b) => a.date.getTime() - b.date.getTime())
+        .map((i) => {
+            return {
+                iid: i.iid,
+                source: i.source,
+                title: i.title,
+                link: i.link,
+                date: i.date,
+                fetchedDate: i.fetchedDate,
+                thumbnails: i.thumbnails ?? [],
+                content: i.content ?? "",
+                snippet: i.snippet ?? "",
+                creator: i.creator,
+                hasRead: i.hasRead,
+                starred: i.starred,
+                hidden: i.hidden,
+                notify: i.notify,
+                serviceRef: i.serviceRef,
+            };
+        });
+    const keys = await fluentDB.items.bulkAdd(entries, { allKeys: true });
     let itemIdx = 0;
     for (const key of keys) {
         items[itemIdx].iid = key;
@@ -288,7 +311,7 @@ export async function insertItems(items: RSSItem[]): Promise<RSSItem[]> {
 
 export function fetchItems(
     background = false,
-    sids: number[] = null,
+    sids: number[] | null = null,
 ): AppThunk<Promise<void>> {
     return async (dispatch, getState) => {
         let promises = new Array<Promise<RSSItem[]>>();
@@ -321,23 +344,14 @@ export function fetchItems(
                           .filter((s) => !s.serviceRef);
             for (let source of sources) {
                 let promise = RSSSource.fetchItems(source);
-                promise
-                    .then(async (items) => {
-                        for (const item of items) {
-                            // Don't await on these, these could take some
-                            // time and they can dispatch independently.
-                            dispatch(attachToThumbnailJobs(item));
-                        }
-                        return items;
-                    })
-                    .then(() =>
-                        dispatch(
-                            updateSource({
-                                ...source,
-                                lastFetched: new Date(),
-                            }),
-                        ),
-                    );
+                promise.then(() =>
+                    dispatch(
+                        updateSource({
+                            ...source,
+                            lastFetched: new Date(),
+                        }),
+                    ),
+                );
                 promise.finally(() => dispatch(fetchItemsIntermediate()));
                 promises.push(promise);
             }
@@ -345,15 +359,16 @@ export function fetchItems(
             const results = await Promise.allSettled(promises);
             return await new Promise<void>((resolve, reject) => {
                 let items = new Array<RSSItem>();
-                results.map((r, i) => {
+                results.forEach((r, i) => {
                     if (r.status === "fulfilled") items.push(...r.value);
                     else {
-                        console.log(r.reason);
+                        console.warn("Fetch result not fulfilled", r.reason);
                         dispatch(fetchItemsFailure(sources[i], r.reason));
                     }
                 });
                 insertItems(items)
                     .then((inserted) => {
+                        // General redux state handling.
                         dispatch(
                             fetchItemsSuccess(
                                 inserted.reverse(),
@@ -374,6 +389,16 @@ export function fetchItems(
                             dispatch(dismissItems());
                         }
                         dispatch(setupAutoFetch());
+                        return inserted;
+                    })
+                    .then((inserted) => {
+                        // Thumbnails.
+                        for (const item of inserted) {
+                            // Don't await on these, these could take some
+                            // time and they can dispatch independently.
+                            dispatch(attachToThumbnailJobs(item));
+                        }
+                        return inserted;
                     })
                     .catch((err) => {
                         dispatch(fetchItemsSuccess([], getState().items));
@@ -381,7 +406,7 @@ export function fetchItems(
                             "A database error has occurred.",
                             String(err),
                         );
-                        console.log(err);
+                        console.error(err);
                         reject(err);
                     });
             });

--- a/src/scripts/models/services/fever.ts
+++ b/src/scripts/models/services/fever.ts
@@ -6,7 +6,7 @@ import { htmlDecode, type FetchFunc } from "../../utils";
 import { RSSItem } from "../item";
 import { SourceRule } from "../rule";
 import { generateThumbnailAttrList } from "../../thumb-utils";
-import { fetchPool } from "../../fetch-pool";
+import { GLOBAL_FETCH_POOL } from "../../fetch-pool";
 
 export interface FeverConfigs extends ServiceConfigs {
     type: SyncService.Fever;
@@ -18,11 +18,16 @@ export interface FeverConfigs extends ServiceConfigs {
     useInt32?: boolean;
 }
 
+const defaultFetchFunc: FetchFunc = (
+    resource: string | URL | Request,
+    options?: RequestInit,
+) => GLOBAL_FETCH_POOL.fetch(resource, options);
+
 async function fetchAPI(
     configs: FeverConfigs,
     params: string = "",
     postparams: string = "",
-    fetchFunc: FetchFunc = fetchPool,
+    fetchFunc: FetchFunc = defaultFetchFunc,
 ) {
     const response = await fetchFunc(configs.endpoint + "?api" + params, {
         method: "POST",

--- a/src/scripts/models/services/fever.ts
+++ b/src/scripts/models/services/fever.ts
@@ -163,10 +163,15 @@ export const feverServiceHooks: ServiceHooks = {
             });
             for (const item of parsedItems) {
                 // Try to get the thumbnail of the item
-                item.thumbnails = await generateThumbnailAttrList({
-                    targetLink: item.link,
-                    content: item.content,
-                });
+                const potentialThumbs = (
+                    await Promise.all(
+                        generateThumbnailAttrList({
+                            targetLink: item.link,
+                            content: item.content,
+                        }),
+                    )
+                ).flat();
+                item.thumbnails = potentialThumbs;
                 item.thumb = item.thumbnails?.at(0)?.url;
             }
             return [parsedItems, configs];

--- a/src/scripts/models/services/greader.ts
+++ b/src/scripts/models/services/greader.ts
@@ -279,10 +279,14 @@ export const gReaderServiceHooks: ServiceHooks = {
                         item.link.split("/").slice(0, 3).join("/"),
                     );
                     dom.head.append(baseEl);
-                    const potentialThumbs = await generateThumbnailAttrList({
-                        targetLink: item.link,
-                        content: item.content,
-                    });
+                    const potentialThumbs = (
+                        await Promise.all(
+                            generateThumbnailAttrList({
+                                targetLink: item.link,
+                                content: item.content,
+                            }),
+                        )
+                    ).flat();
                     item.thumbnails = potentialThumbs;
                     if (configs.type == SyncService.Inoreader)
                         item.title = htmlDecode(item.title);

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -10,6 +10,7 @@ import {
 import {
     RSSItem,
     insertItems,
+    attachToThumbnailJobs,
     ItemActionTypes,
     FETCH_ITEMS,
     MARK_READ,
@@ -331,6 +332,11 @@ export function addSource(
                             feed.items,
                         );
                         await insertItems(items);
+                        for (const item of items) {
+                            // Don't await on these, these could take some
+                            // time and they can dispatch independently.
+                            dispatch(attachToThumbnailJobs(item));
+                        }
                         return newSource.sid;
                     case false:
                         if (ignoreDuplicates) {

--- a/src/scripts/models/source.ts
+++ b/src/scripts/models/source.ts
@@ -70,7 +70,7 @@ export class RSSSource {
     private static async checkItem(
         source: RSSSource,
         item: MyParserItem,
-    ): Promise<RSSItem> {
+    ): Promise<RSSItem | null> {
         let i = new RSSItem(item, source);
         const items = await db.fluentDB.items
             .where("date")
@@ -87,23 +87,13 @@ export class RSSSource {
         }
     }
 
-    static checkItems(
+    static async checkItems(
         source: RSSSource,
         items: MyParserItem[],
     ): Promise<RSSItem[]> {
-        return new Promise<RSSItem[]>((resolve, reject) => {
-            let p = new Array<Promise<RSSItem>>();
-            for (let item of items) {
-                p.push(this.checkItem(source, item));
-            }
-            Promise.all(p)
-                .then((values) => {
-                    resolve(values.filter((v) => v != null));
-                })
-                .catch((e) => {
-                    reject(e);
-                });
-        });
+        let p = items.map((item) => this.checkItem(source, item));
+        const results = await Promise.all(p);
+        return results.filter((v) => v != null);
     }
 
     static async fetchItems(source: RSSSource) {
@@ -331,8 +321,8 @@ export function addSource(
                             newSource,
                             feed.items,
                         );
-                        await insertItems(items);
-                        for (const item of items) {
+                        const inserted = await insertItems(items);
+                        for (const item of inserted) {
                             // Don't await on these, these could take some
                             // time and they can dispatch independently.
                             dispatch(attachToThumbnailJobs(item));

--- a/src/scripts/thumb-utils.ts
+++ b/src/scripts/thumb-utils.ts
@@ -1,5 +1,5 @@
 import { ThumbnailTypePref } from "../schema-types";
-import { Pool, startPool, fetchPool } from "./fetch-pool";
+import { Pool, startPool } from "./fetch-pool";
 
 const THUMBNAIL_FETCH_POOLS = new Map<String, Pool>();
 
@@ -25,12 +25,7 @@ export interface ThumbnailAttributes {
 async function fetchHead(url: URL): Promise<string> {
     const controller = new AbortController();
     let pool = getPool(url);
-    const response = await fetchPool(
-        url,
-        { signal: controller.signal },
-        undefined,
-        pool,
-    );
+    const response = await pool.fetch(url, { signal: controller.signal });
     let result = "";
     if (!response.ok || !response.body) return result;
     const stream = response.body.pipeThrough(new TextDecoderStream());
@@ -106,12 +101,7 @@ async function urlToThumbnailAttributes(
     }
     const realURL = new URL(url);
     let pool = getPool(realURL);
-    const response = await fetchPool(
-        realURL,
-        { method: "HEAD" },
-        undefined,
-        pool,
-    );
+    const response = await pool.fetch(realURL, { method: "HEAD" });
     if (!response.ok)
         return {
             url,

--- a/src/scripts/thumb-utils.ts
+++ b/src/scripts/thumb-utils.ts
@@ -122,10 +122,11 @@ export type ThumbnailOptions = {
  * This function is very complex because there's so many different ways to try to infer what
  * the thumbnail should be.
  */
-export async function generateThumbnailAttrList(
+export function generateThumbnailAttrList(
     opt: ThumbnailOptions,
-): Promise<ThumbnailAttributes[]> {
-    let output = [];
+): Promise<ThumbnailAttributes[]>[] {
+    let output: Promise<ThumbnailAttributes[]>[] = [];
+    const wrapSingle = (x: any) => [x];
     if (opt.targetLink) {
         if (
             !opt.targetLink.startsWith("http://") &&
@@ -138,58 +139,60 @@ export async function generateThumbnailAttrList(
             return [];
         }
 
-        let potentialThumbs: ThumbnailAttributes[] | null = null;
-        try {
-            potentialThumbs = await fetchOpenGraphThumb(
-                new URL(opt.targetLink),
-            );
-        } catch (e) {
-            // We don't need an OpenGraph thumbnail. Skip it if it fails.
-            console.warn(
-                `Failed to fetch OpenGraph thumb from ${opt.targetLink}`,
-                e,
-            );
-        }
-        if (potentialThumbs && potentialThumbs.length > 0) {
-            output.push(...potentialThumbs);
-        }
+        const targetLinkJob = async () => {
+            let potentialThumbs: ThumbnailAttributes[] | null = null;
+            try {
+                potentialThumbs = await fetchOpenGraphThumb(
+                    new URL(opt.targetLink),
+                );
+            } catch (e) {
+                // We don't need an OpenGraph thumbnail. Skip it if it fails.
+                console.warn(
+                    `Failed to fetch OpenGraph thumb from ${opt.targetLink}`,
+                    e,
+                );
+            }
+            return potentialThumbs ?? [];
+        };
+
+        output.push(targetLinkJob());
     }
     if (opt.mediaThumbnails) {
         const images = opt.mediaThumbnails.filter((t) => t.$?.url);
         for (const image of images)
             output.push(
-                await urlToThumbnailAttributes(
+                urlToThumbnailAttributes(
                     image.$.url,
                     "unknown",
                     ThumbnailTypePref.MediaThumbnail,
-                ),
+                ).then(wrapSingle),
             );
     }
     if (opt.parsedThumb) {
         output.push(
-            await urlToThumbnailAttributes(
+            urlToThumbnailAttributes(
                 opt.parsedThumb,
                 "unknown",
                 ThumbnailTypePref.Thumb,
-            ),
+            ).then(wrapSingle),
         );
     }
     if (opt.imageTag?.$?.url) {
         output.push(
-            await urlToThumbnailAttributes(
+            urlToThumbnailAttributes(
                 opt.imageTag.$.url,
                 "image",
                 ThumbnailTypePref.Other,
-            ),
+            ).then(wrapSingle),
         );
     }
     if (opt.parsedImage && typeof opt.parsedImage === "string") {
         output.push(
-            await urlToThumbnailAttributes(
+            urlToThumbnailAttributes(
                 opt.parsedImage as string,
                 "image",
                 ThumbnailTypePref.Other,
-            ),
+            ).then(wrapSingle),
         );
     }
     if (opt.mediaContent) {
@@ -203,11 +206,11 @@ export async function generateThumbnailAttrList(
         );
         for (const image of images)
             output.push(
-                await urlToThumbnailAttributes(
+                urlToThumbnailAttributes(
                     image.$.url,
                     image.$.medium,
                     ThumbnailTypePref.Other,
-                ),
+                ).then(wrapSingle),
             );
     }
     if (opt.content && opt.targetLink != null) {
@@ -221,19 +224,20 @@ export async function generateThumbnailAttrList(
         let img = dom.querySelector("img");
         if (img && img.src)
             output.push(
-                await urlToThumbnailAttributes(
+                urlToThumbnailAttributes(
                     img.src,
                     "image",
                     ThumbnailTypePref.Other,
-                ),
+                ).then(wrapSingle),
             );
     }
-    output = output.map((t) => {
-        return {
-            medium: t.medium,
-            type: t.type,
-            url: new URL(t.url, opt.targetLink).toString(),
-        };
-    });
+
+    // Remap the url to be re-rooted to the targetLink, fixing relative URLs.
+    const reRootTarget = (xs: ThumbnailAttributes[]): ThumbnailAttributes[] => {
+        return xs.map((x: ThumbnailAttributes) => {
+            return { ...x, url: new URL(x.url, opt.targetLink).toString() };
+        });
+    };
+    output = output.map((t) => t.then(reRootTarget));
     return output;
 }

--- a/src/scripts/thumb-utils.ts
+++ b/src/scripts/thumb-utils.ts
@@ -1,4 +1,17 @@
 import { ThumbnailTypePref } from "../schema-types";
+import { Pool, startPool, fetchPool } from "./fetch-pool";
+
+const THUMBNAIL_FETCH_POOLS = new Map<String, Pool>();
+
+function getPool(url: URL): Pool {
+    if (THUMBNAIL_FETCH_POOLS.has(url.hostname)) {
+        return THUMBNAIL_FETCH_POOLS.get(url.hostname);
+    }
+    const pool = new Pool(20, 10, 20);
+    startPool(pool);
+    THUMBNAIL_FETCH_POOLS.set(url.hostname, pool);
+    return pool;
+}
 
 export interface ThumbnailAttributes {
     medium: "image" | "video";
@@ -11,7 +24,13 @@ export interface ThumbnailAttributes {
  */
 async function fetchHead(url: URL): Promise<string> {
     const controller = new AbortController();
-    const response = await fetch(url, { signal: controller.signal });
+    let pool = getPool(url);
+    const response = await fetchPool(
+        url,
+        { signal: controller.signal },
+        undefined,
+        pool,
+    );
     let result = "";
     if (!response.ok || !response.body) return result;
     const stream = response.body.pipeThrough(new TextDecoderStream());
@@ -85,7 +104,14 @@ async function urlToThumbnailAttributes(
             type,
         };
     }
-    const response = await fetch(url, { method: "HEAD" });
+    const realURL = new URL(url);
+    let pool = getPool(realURL);
+    const response = await fetchPool(
+        realURL,
+        { method: "HEAD" },
+        undefined,
+        pool,
+    );
     if (!response.ok)
         return {
             url,

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -411,6 +411,15 @@ export function dateCompare(itemDate: Date, limitDate: Date, before = false) {
     return true;
 }
 
+/**
+ * Create a promise that resolves with the result after the given
+ * milliseconds.
+ */
+export function timeoutPromise<T>(ms: number, result: T = undefined): Promise<T> {
+    return new Promise((res) => setTimeout(() => res(result), ms));
+}
+
 export const exportedForTesting = {
     getPotentialFavicons,
 };
+

--- a/src/scripts/utils.ts
+++ b/src/scripts/utils.ts
@@ -415,11 +415,13 @@ export function dateCompare(itemDate: Date, limitDate: Date, before = false) {
  * Create a promise that resolves with the result after the given
  * milliseconds.
  */
-export function timeoutPromise<T>(ms: number, result: T = undefined): Promise<T> {
+export function timeoutPromise<T>(
+    ms: number,
+    result: T = undefined,
+): Promise<T> {
     return new Promise((res) => setTimeout(() => res(result), ms));
 }
 
 export const exportedForTesting = {
     getPotentialFavicons,
 };
-

--- a/tests/scripts/test_fetch-pool.ts
+++ b/tests/scripts/test_fetch-pool.ts
@@ -16,37 +16,25 @@ describe("fetchPool", () => {
     });
 
     it("can fetch", () => {
-        const pool: fetchPool.Pool = {
-            total: 2,
-            refill_rate: 0,
-            __available: 2,
-            __started: true,
-        };
-        return fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
+        const pool = new fetchPool.Pool(2, 0, 2);
+        pool.__started = true;
+        return pool.fetch("https://a.url.here");
     });
 
     it("can fetch twice", async () => {
-        const pool: fetchPool.Pool = {
-            total: 2,
-            refill_rate: 0,
-            __available: 2,
-            __started: true,
-        };
-        await fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
-        return fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
+        const pool = new fetchPool.Pool(2, 0, 2);
+        pool.__started = true;
+        await pool.fetch("https://a.url.here");
+        return pool.fetch("https://a.url.here");
     });
 
     it("can't fetch thrice", async () => {
-        const pool: fetchPool.Pool = {
-            total: 2,
-            refill_rate: 0,
-            __available: 2,
-            __started: true,
-        };
-        await fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
-        await fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
+        const pool = new fetchPool.Pool(2, 0, 2);
+        pool.__started = true;
+        await pool.fetch("https://a.url.here");
+        await pool.fetch("https://a.url.here");
         try {
-            await fetchPool.fetchPool("hello", undefined, 10, pool);
+            await pool.fetch("hello", undefined, 10);
         } catch (e) {
             expect(e.message).contains("fetchPool: Timeout");
             return;
@@ -55,19 +43,10 @@ describe("fetchPool", () => {
     });
 
     it("can't fetch with none available", async () => {
-        const pool: fetchPool.Pool = {
-            total: 1,
-            refill_rate: 0,
-            __available: 0,
-            __started: true,
-        };
+        const pool: fetchPool.Pool = new fetchPool.Pool(1, 0, 0);
+        pool.__started = true;
         try {
-            await fetchPool.fetchPool(
-                "https://a.url.here",
-                undefined,
-                50,
-                pool,
-            );
+            await pool.fetch("https://a.url.here", undefined, 50);
         } catch (e) {
             expect(e.message).contains("fetchPool: Timeout");
             return;
@@ -76,14 +55,9 @@ describe("fetchPool", () => {
     });
 
     it("can refill", async () => {
-        const pool: fetchPool.Pool = {
-            total: 1,
-            refill_rate: 1000,
-            __available: 0,
-            __started: false,
-        };
-        const timeout = fetchPool.startPool(pool);
-        await fetchPool.fetchPool("https://a.url.here", undefined, 0, pool);
-        fetchPool.stopPool(timeout);
+        const pool = new fetchPool.Pool(1, 1000, 0);
+        fetchPool.startPool(pool);
+        await pool.fetch("https://a.url.here");
+        fetchPool.stopPool(pool);
     });
 });


### PR DESCRIPTION
Implement lazy-loading for thumbnail fetching.

We give thumbnails exactly 1 second to load to prevent flashing, but after that we give up and let them load
in the background without waiting. This is implemented by keeping track of an item's `thumbnailJobs`, and
then dispatching state/updating the DB on their completion.

Fixes #171.