### PR TITLE
Allow migration from old config name seamlessly

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,7 +1,7 @@
 import { app, ipcMain, Menu, nativeTheme } from "electron";
 import { ThemeSettings, type SchemaTypes } from "./schema-types";
-import { store } from "./main/settings";
-import performUpdate from "./main/update-scripts";
+import { getStore } from "./main/settings";
+import { performUpdate, maybeRenameOldConfig } from "./main/update-scripts";
 import { WindowManager } from "./main/window";
 import { type CustomArgs } from "./general-types";
 import minimist from "minimist";
@@ -24,31 +24,38 @@ function parseArgs(): unknown {
 
 // Main Program -----------------------------------------------------------------------------------
 
-if (!process.mas) {
-    const locked = app.requestSingleInstanceLock();
-    if (!locked) {
-        app.quit();
-    }
-}
-
-if (app.isPackaged) {
-    // Force the userData path to use the proper internal name. This will vary for electron-builder
-    // applications depending on what the proposed "name" or "productName" will be, but we want
-    // this to be consistent for the packaged application.
-    const appDataPath = app.getPath("appData");
-    const internalAppName = "fluentflame-reader";
-    app.setPath("userData", `${appDataPath}/${internalAppName}`);
-    if (process.platform === "win32") {
-        app.setAppUserModelId("org.fluentflame.fluentflamereader");
-    }
-} else {
-    // Persist to using "Electron" for userData in development.
-    app.setAppUserModelId(process.execPath);
-}
-
 let restarting = false;
 
 function init() {
+    // We MUST have path correction before any other app calls, as they can be stateful and those calls
+    // may create directories or files based on these paths.
+    if (app.isPackaged) {
+        // Force the userData path to use the proper internal name. This will vary for electron-builder
+        // applications depending on what the proposed "name" or "productName" will be, but we want
+        // this to be consistent for the packaged application.
+        const appDataPath = app.getPath("appData");
+        const internalAppName = "fluentflame-reader";
+        maybeRenameOldConfig(
+            `${appDataPath}/Fluentflame Reader`,
+            `${appDataPath}/${internalAppName}`,
+        );
+        app.setPath("userData", `${appDataPath}/${internalAppName}`);
+        if (process.platform === "win32") {
+            app.setAppUserModelId("org.fluentflame.fluentflamereader");
+        }
+    } else {
+        // Persist to using "Electron" for userData in development.
+        app.setAppUserModelId(process.execPath);
+    }
+
+    if (!process.mas) {
+        const locked = app.requestSingleInstanceLock();
+        if (!locked) {
+            app.quit();
+        }
+    }
+
+    const store = getStore();
     performUpdate(store);
     nativeTheme.themeSource = store.get("theme", ThemeSettings.Default);
 
@@ -157,6 +164,7 @@ app.on("window-all-closed", () => {
 });
 
 ipcMain.handle("import-all-settings", (_, configs: SchemaTypes) => {
+    const store = getStore();
     restarting = true;
     store.clear();
     for (let [key, value] of Object.entries(configs)) {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -15,41 +15,51 @@ import {
 import { ipcMain, session, nativeTheme, app } from "electron";
 import { WindowManager } from "./window";
 
-export const store = new Store<SchemaTypes>();
+let STORE = undefined;
+
+/**
+ * Return the electron-store singleton.
+ */
+export function getStore(): Store<SchemaTypes> {
+    if (STORE === undefined) {
+        STORE = new Store<SchemaTypes>();
+    }
+    return STORE;
+}
 
 const GROUPS_STORE_KEY = "sourceGroups";
 ipcMain.handle("set-groups", (_, groups: SourceGroup[]) => {
-    store.set(GROUPS_STORE_KEY, groups);
+    getStore().set(GROUPS_STORE_KEY, groups);
 });
 ipcMain.on("get-groups", (event) => {
-    event.returnValue = store.get(GROUPS_STORE_KEY, []);
+    event.returnValue = getStore().get(GROUPS_STORE_KEY, []);
 });
 
 const MENU_STORE_KEY = "menuOn";
 ipcMain.on("get-menu", (event) => {
-    event.returnValue = store.get(MENU_STORE_KEY, false);
+    event.returnValue = getStore().get(MENU_STORE_KEY, false);
 });
 ipcMain.handle("set-menu", (_, state: boolean) => {
-    store.set(MENU_STORE_KEY, state);
+    getStore().set(MENU_STORE_KEY, state);
 });
 
 const PAC_STORE_KEY = "pac";
 const PAC_STATUS_KEY = "pacOn";
 function getProxyStatus() {
-    return store.get(PAC_STATUS_KEY, false);
+    return getStore().get(PAC_STATUS_KEY, false);
 }
 function toggleProxyStatus() {
-    store.set(PAC_STATUS_KEY, !getProxyStatus());
+    getStore().set(PAC_STATUS_KEY, !getProxyStatus());
     setProxy();
 }
 function getProxy() {
-    return store.get(PAC_STORE_KEY, "");
+    return getStore().get(PAC_STORE_KEY, "");
 }
 function setProxy(address = null) {
     if (!address) {
         address = getProxy();
     } else {
-        store.set(PAC_STORE_KEY, address);
+        getStore().set(PAC_STORE_KEY, address);
     }
     if (getProxyStatus()) {
         let rules = { pacScript: address };
@@ -72,10 +82,10 @@ ipcMain.handle("set-proxy", (_, address = null) => {
 
 const THEME_STORE_KEY = "theme";
 ipcMain.on("get-theme", (event) => {
-    event.returnValue = store.get(THEME_STORE_KEY, ThemeSettings.Default);
+    event.returnValue = getStore().get(THEME_STORE_KEY, ThemeSettings.Default);
 });
 ipcMain.handle("set-theme", (_, theme: ThemeSettings) => {
-    store.set(THEME_STORE_KEY, theme);
+    getStore().set(THEME_STORE_KEY, theme);
     nativeTheme.themeSource = theme;
 });
 ipcMain.on("get-theme-dark-color", (event) => {
@@ -95,43 +105,43 @@ export function setThemeListener(manager: WindowManager) {
 
 const ANIMATION_MOTION_PREF_KEY = "animationMotionPref";
 ipcMain.on("get-animation-motion-pref", (event) => {
-    event.returnValue = store.get(
+    event.returnValue = getStore().get(
         ANIMATION_MOTION_PREF_KEY,
         AnimationMotionPref.System,
     );
 });
 ipcMain.handle("set-animation-motion-pref", (_, pref: AnimationMotionPref) => {
-    store.set(ANIMATION_MOTION_PREF_KEY, pref);
+    getStore().set(ANIMATION_MOTION_PREF_KEY, pref);
 });
 
 const USE_NATIVE_WINDOW_FRAME_KEY = "useNativeWindowFramePref";
 export function getNativeWindowFramePref(): boolean {
-    return store.get(USE_NATIVE_WINDOW_FRAME_KEY, false);
+    return getStore().get(USE_NATIVE_WINDOW_FRAME_KEY, false);
 }
 ipcMain.on("get-window-native-frame-pref", (event) => {
     event.returnValue = getNativeWindowFramePref();
 });
 ipcMain.handle("set-window-native-frame-pref", (_, pref: boolean) => {
-    store.set(USE_NATIVE_WINDOW_FRAME_KEY, pref);
+    getStore().set(USE_NATIVE_WINDOW_FRAME_KEY, pref);
 });
 
 const THUMBNAIL_TYPE_PREF = "thumbnailTypePref";
 ipcMain.on("get-thumbnail-type-pref", (event) => {
-    event.returnValue = store.get(
+    event.returnValue = getStore().get(
         THUMBNAIL_TYPE_PREF,
         ThumbnailTypePref.OpenGraph,
     );
 });
 ipcMain.handle("set-thumbnail-type-pref", (_, pref: ThumbnailTypePref) => {
-    store.set(THUMBNAIL_TYPE_PREF, pref);
+    getStore().set(THUMBNAIL_TYPE_PREF, pref);
 });
 
 const LOCALE_STORE_KEY = "locale";
 ipcMain.handle("set-locale", (_, option: string) => {
-    store.set(LOCALE_STORE_KEY, option);
+    getStore().set(LOCALE_STORE_KEY, option);
 });
 function getLocaleSettings() {
-    return store.get(LOCALE_STORE_KEY, "default");
+    return getStore().get(LOCALE_STORE_KEY, "default");
 }
 ipcMain.on("get-locale-settings", (event) => {
     event.returnValue = getLocaleSettings();
@@ -144,23 +154,23 @@ ipcMain.on("get-locale", (event) => {
 
 const FONT_SIZE_STORE_KEY = "fontSize";
 ipcMain.on("get-font-size", (event) => {
-    event.returnValue = store.get(FONT_SIZE_STORE_KEY, 16);
+    event.returnValue = getStore().get(FONT_SIZE_STORE_KEY, 16);
 });
 ipcMain.handle("set-font-size", (_, size: number) => {
-    store.set(FONT_SIZE_STORE_KEY, size);
+    getStore().set(FONT_SIZE_STORE_KEY, size);
 });
 
 const FONT_STORE_KEY = "fontFamily";
 ipcMain.on("get-font", (event) => {
-    event.returnValue = store.get(FONT_STORE_KEY, "");
+    event.returnValue = getStore().get(FONT_STORE_KEY, "");
 });
 ipcMain.handle("set-font", (_, font: string) => {
-    store.set(FONT_STORE_KEY, font);
+    getStore().set(FONT_STORE_KEY, font);
 });
 
 ipcMain.on("get-all-settings", (event) => {
     let output = {};
-    for (let [key, value] of store) {
+    for (let [key, value] of getStore()) {
         output[key] = value;
     }
     event.returnValue = output;
@@ -168,56 +178,62 @@ ipcMain.on("get-all-settings", (event) => {
 
 const DEFAULT_OPEN_TARGET_STORE_KEY = "defaultOpenTarget";
 ipcMain.handle("get-default-open-target-pref", () => {
-    return store.get(DEFAULT_OPEN_TARGET_STORE_KEY, SourceOpenTarget.Local);
+    return getStore().get(
+        DEFAULT_OPEN_TARGET_STORE_KEY,
+        SourceOpenTarget.Local,
+    );
 });
 ipcMain.handle(
     "set-default-open-target-pref",
     (_, openTarget: SourceOpenTarget) => {
-        store.set(DEFAULT_OPEN_TARGET_STORE_KEY, openTarget);
+        getStore().set(DEFAULT_OPEN_TARGET_STORE_KEY, openTarget);
     },
 );
 
 const FETCH_INTEVAL_STORE_KEY = "fetchInterval";
 ipcMain.on("get-fetch-interval", (event) => {
-    event.returnValue = store.get(FETCH_INTEVAL_STORE_KEY, 0);
+    event.returnValue = getStore().get(FETCH_INTEVAL_STORE_KEY, 0);
 });
 ipcMain.handle("set-fetch-interval", (_, interval: number) => {
-    store.set(FETCH_INTEVAL_STORE_KEY, interval);
+    getStore().set(FETCH_INTEVAL_STORE_KEY, interval);
 });
 
 const SEARCH_ENGINE_STORE_KEY = "searchEngine";
 ipcMain.on("get-search-engine", (event) => {
-    event.returnValue = store.get(
+    event.returnValue = getStore().get(
         SEARCH_ENGINE_STORE_KEY,
         SearchEngines.Startpage,
     );
 });
 ipcMain.handle("set-search-engine", (_, engine: SearchEngines) => {
-    store.set(SEARCH_ENGINE_STORE_KEY, engine);
+    getStore().set(SEARCH_ENGINE_STORE_KEY, engine);
 });
 
 const SERVICE_CONFIGS_STORE_KEY = "serviceConfigs";
 ipcMain.on("get-service-configs", (event) => {
-    event.returnValue = store.get(SERVICE_CONFIGS_STORE_KEY, {
+    event.returnValue = getStore().get(SERVICE_CONFIGS_STORE_KEY, {
         type: SyncService.None,
     });
 });
 ipcMain.handle("set-service-configs", (_, configs: ServiceConfigs) => {
-    store.set(SERVICE_CONFIGS_STORE_KEY, configs);
+    getStore().set(SERVICE_CONFIGS_STORE_KEY, configs);
 });
 
 const FILTER_TYPE_STORE_KEY = "filterType";
 ipcMain.on("get-filter-type", (event) => {
-    event.returnValue = store.get(FILTER_TYPE_STORE_KEY, null);
+    event.returnValue = getStore().get(FILTER_TYPE_STORE_KEY, null);
 });
 ipcMain.handle("set-filter-type", (_, filterType: number) => {
-    store.set(FILTER_TYPE_STORE_KEY, filterType);
+    getStore().set(FILTER_TYPE_STORE_KEY, filterType);
 });
 
 const VIEW_CONFIG_STORE_KEY = "viewConfig";
 ipcMain.on("get-view-config", (event) => {
-    event.returnValue = store.get(VIEW_CONFIG_STORE_KEY, defaultViewConfig());
+    event.returnValue = getStore().get(
+        VIEW_CONFIG_STORE_KEY,
+        defaultViewConfig(),
+    );
 });
 ipcMain.handle("set-view-config", (_, config: ViewConfig) => {
-    store.set(VIEW_CONFIG_STORE_KEY, config);
+    getStore().set(VIEW_CONFIG_STORE_KEY, config);
 });

--- a/src/main/update-scripts.ts
+++ b/src/main/update-scripts.ts
@@ -1,10 +1,33 @@
 import Store from "electron-store";
 import { SchemaTypes } from "../schema-types";
 import pkg from "../../package.json";
+import { existsSync, renameSync } from "fs";
 
-export default function performUpdate(store: Store<SchemaTypes>) {
+export function performUpdate(store: Store<SchemaTypes>) {
     let curVersion = store.get("version", null);
     if (pkg.version != curVersion) {
         store.set("version", pkg.version);
+    }
+}
+
+/**
+ * We once incorrectly named the config dir "Fluentflame Reader", so this lets
+ * us fix that mistake by renaming it to the desired userPath before start up.
+ */
+export function maybeRenameOldConfig(oldUserPath: string, newUserPath: string) {
+    if (existsSync(oldUserPath)) {
+        console.log(
+            `fluentflame-reader: Found erroneous config dir name: ${oldUserPath}`,
+        );
+        if (!existsSync(newUserPath)) {
+            renameSync(oldUserPath, newUserPath);
+            console.log(
+                `fluentflame-reader: Renamed ${oldUserPath} -> ${newUserPath}`,
+            );
+        } else {
+            console.warn(
+                `fluentflame-reader: Can't move old dir because ${newUserPath} exists`,
+            );
+        }
     }
 }


### PR DESCRIPTION
Previously, our config was named "Fluentflame Reader" on some systems. This was a mistake. We can check for this error on start up, and correct it.

To get this to work, we have to lazily-init the Electron store singleton, which we now access through the `getStore()` function.