### PR TITLE
Fix feed offset calculation

### DIFF
--- a/src/scripts/models/feed.ts
+++ b/src/scripts/models/feed.ts
@@ -136,11 +136,11 @@ export class RSSFeed {
         // for a rewrite.
         return await db.fluentDB.items
             .orderBy("date")
-            .reverse()
-            .offset(skip)
             .filter(
                 (item) => feed.sids.includes(item.source) && predicate(item),
             )
+            .reverse()
+            .offset(skip)
             .limit(LOAD_QUANTITY)
             .toArray();
     }


### PR DESCRIPTION
During rendering, it was possible to get duplicate posts during the "load more" operation. Load more works by operating on this offset, which previously was computing the offset before the predicate filter.