### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "update-actions"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"


### PR DESCRIPTION
This PR adds the use of github dendabot to our repository, which will be updated weekly. This would send us  updates for our github actions workflows and for our npm packages.

This could help us attend to things like applying fixes to vulnerabilities faster, as note: I’ve usually only used this to update github actions so I’m not sure if it’s okay in the npm section or if it’s too basic, I understand that we could subsequently adjust some things in the repository security tab