### PR TITLE
Switch nix build to use importNpmLock

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,9 +5,11 @@
   fetchFromGitHub,
   makeDesktopItem,
   makeWrapper,
+  importNpmLock,
 }:
 let
   pname = "fluentflame-reader";
+  version = "2.2.0-dev.1";
   myElectron = electron;
   desktopItem = makeDesktopItem {
     name = pname;
@@ -22,9 +24,16 @@ in
 
 buildNpmPackage {
   inherit pname;
-  version = "2.2.0-dev.1";
+  inherit version;
   src = ../.;
-  npmDepsHash = "sha256-gPjDs6VTqIyJlLNbcZvmOnatrcZWRzXZyzo3PXu3Ivo=";
+  
+  # See for details on why we do this:
+  # https://nixos.org/manual/nixpkgs/stable/#javascript-buildNpmPackage-importNpmLock
+  npmDeps = importNpmLock {
+    npmRoot = ../.;
+  };
+  npmConfigHook = importNpmLock.npmConfigHook;
+
   makeCacheWritable = true;
 
   env = {


### PR DESCRIPTION
This makes it MUCH easier to update npm/pnpm dependencies. Now we can use dependabot!